### PR TITLE
PVP-151 Assign default avatar upon registration

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -138,6 +138,9 @@ dependencies {
     // Health connect
     implementation("androidx.health.connect:connect-client:1.1.0-alpha07")
 
+    // Images
+    implementation("com.caverock:androidsvg-aar:1.4")
+
     // JUnit
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/java/com/pvp/app/api/UserService.kt
+++ b/app/src/main/java/com/pvp/app/api/UserService.kt
@@ -1,5 +1,6 @@
 package com.pvp.app.api
 
+import androidx.compose.ui.graphics.ImageBitmap
 import com.pvp.app.model.User
 import kotlinx.coroutines.flow.Flow
 
@@ -27,4 +28,13 @@ interface UserService : DocumentsCollection {
      * Removes an user from the database with all associated children data.
      */
     suspend fun remove(email: String)
+
+    /**
+     * Resolves the avatar of the user by its email. User can have decorated avatar, which requires
+     * to be resolved by this method.
+     *
+     * @param email of the user
+     * @return the avatar of the user
+     */
+    suspend fun resolveAvatar(email: String): ImageBitmap
 }

--- a/app/src/main/java/com/pvp/app/common/Utils.kt
+++ b/app/src/main/java/com/pvp/app/common/Utils.kt
@@ -1,6 +1,13 @@
 package com.pvp.app.common
 
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Picture
+import android.graphics.drawable.PictureDrawable
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.asImageBitmap
 import java.time.Duration
+
 /**
  * Parses Duration object to a string
  * Format <HH> h <mm> min
@@ -18,4 +25,23 @@ fun getDurationString(duration: Duration): String {
             append("${if (hours > 0) " " else ""}$minutes min")
         }
     }
+}
+
+fun Picture.toImageBitmap(): ImageBitmap {
+    PictureDrawable(this)
+        .run {
+            val bitmap = Bitmap.createBitmap(
+                intrinsicWidth,
+                intrinsicHeight,
+                Bitmap.Config.ARGB_8888
+            )
+
+            val canvas = Canvas(bitmap)
+
+            setBounds(0, 0, canvas.width, canvas.height)
+
+            draw(canvas)
+
+            return bitmap.asImageBitmap()
+        }
 }

--- a/app/src/main/java/com/pvp/app/service/UserServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/UserServiceImpl.kt
@@ -1,10 +1,17 @@
 package com.pvp.app.service
 
+import android.content.Context
+import androidx.compose.ui.graphics.ImageBitmap
+import com.caverock.androidsvg.SVG
+import com.caverock.androidsvg.SVGParseException
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.snapshots
+import com.pvp.app.R
 import com.pvp.app.api.AuthenticationService
 import com.pvp.app.api.UserService
+import com.pvp.app.common.toImageBitmap
 import com.pvp.app.model.User
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.firstOrNull
@@ -16,6 +23,8 @@ import javax.inject.Provider
 
 class UserServiceImpl @Inject constructor(
     private val authenticationServiceProvider: Provider<AuthenticationService>,
+    @ApplicationContext
+    private val context: Context,
     private val database: FirebaseFirestore
 ) : UserService {
 
@@ -52,5 +61,20 @@ class UserServiceImpl @Inject constructor(
             .document(email)
             .delete()
             .await()
+    }
+
+    override suspend fun resolveAvatar(email: String): ImageBitmap {
+        // TODO: In the future, we will resolve the avatar by checking user's bought decorations.
+        // For now, we will just return a default avatar.
+        return try {
+            SVG
+                .getFromResource(context.resources, R.raw.avatar)
+                .renderToPicture()
+                .toImageBitmap()
+        } catch (e: SVGParseException) {
+            e.printStackTrace()
+
+            error("Failed to resolve user avatar")
+        }
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
@@ -2,6 +2,7 @@ package com.pvp.app.ui.screen.layout
 
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -11,7 +12,6 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Dehaze
-import androidx.compose.material.icons.outlined.Person
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -25,14 +25,18 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
-import com.pvp.app.model.User
 import com.pvp.app.ui.common.navigateWithPopUp
 import com.pvp.app.ui.router.Route
 import com.pvp.app.ui.router.Router
@@ -45,7 +49,7 @@ import kotlinx.coroutines.launch
 fun LayoutScreenAuthenticated(
     controller: NavHostController,
     scope: CoroutineScope,
-    user: User?
+    viewModel: LayoutViewModel = hiltViewModel()
 ) {
     CalendarTheme {
         Surface(modifier = Modifier.fillMaxSize()) {
@@ -73,13 +77,15 @@ fun LayoutScreenAuthenticated(
                 },
                 drawerState = stateDrawer
             ) {
+                val stateLayout by viewModel.state.collectAsStateWithLifecycle()
+
                 Scaffold(topBar = {
                     Header(
                         controller = controller,
                         route = screen,
                         scope = scope,
                         state = stateDrawer,
-                        user = user
+                        userAvatar = stateLayout.userAvatar!!
                     )
                 }) {
                     Router(
@@ -103,39 +109,34 @@ private fun Header(
     route: Route,
     scope: CoroutineScope,
     state: DrawerState,
-    user: User?
+    userAvatar: ImageBitmap
 ) {
     TopAppBar(
         actions = {
-            user?.let {
-                IconButton(
-                    modifier = Modifier
-                        .padding(8.dp)
-                        .clip(RoundedCornerShape(36.dp))
-                        .border(
-                            BorderStroke(2.dp, MaterialTheme.colorScheme.surfaceContainerHighest),
-                            RoundedCornerShape(36.dp)
-                        ),
-                    onClick = {
-                        controller.navigateWithPopUp(Route.Profile.route)
-                    }
-                ) {
-                    Icon(
-                        contentDescription = "Profile screen icon",
-                        imageVector = Icons.Outlined.Person
-                    )
+            IconButton(
+                modifier = Modifier
+                    .padding(8.dp)
+                    .clip(RoundedCornerShape(36.dp))
+                    .border(
+                        BorderStroke(2.dp, MaterialTheme.colorScheme.surfaceContainerHighest),
+                        RoundedCornerShape(36.dp)
+                    ),
+                onClick = {
+                    controller.navigateWithPopUp(Route.Profile.route)
                 }
+            ) {
+                Image(
+                    contentDescription = "Profile screen icon",
+                    painter = BitmapPainter(userAvatar),
+                )
             }
-
         },
         modifier = modifier,
         navigationIcon = {
-            user?.let {
-                HeaderNavigationIcon(
-                    scope = scope,
-                    state = state
-                )
-            }
+            HeaderNavigationIcon(
+                scope = scope,
+                state = state
+            )
         },
         title = {
             HeaderTitle(route = route)

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenBootstrap.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenBootstrap.kt
@@ -35,7 +35,6 @@ fun LayoutScreenBootstrap(
 
     LayoutScreenAuthenticated(
         controller = rememberNavController(),
-        scope = rememberCoroutineScope(),
-        user = state.user.value
+        scope = rememberCoroutineScope()
     )
 }

--- a/app/src/main/res/raw/avatar.svg
+++ b/app/src/main/res/raw/avatar.svg
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1024" height="1024" viewBox="0 0 1024 1024" xml:space="preserve">
+<desc>Created with Fabric.js 5.3.0</desc>
+<defs>
+</defs>
+<g transform="matrix(-2.4170463531 0 0 -2.4170463531 343.7995118549 790.4805594964)" id="sY47uQkzK_M0_P4PCJhu0"  >
+<path style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(183,183,183); fill-rule: nonzero; opacity: 1;"  transform=" translate(-40, -40)" d="M 60 40 L 80 80 L 40 80 L 0 80 L 20 40 L 40 0 L 60 40 z" stroke-linecap="round" />
+</g>
+<g transform="matrix(-2.4170463532 0 0 -2.4170463532 680.2004881629 790.4805595023)" id="fQ5nKpN0l8Vqb3NmizD1c"  >
+<path style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(183,183,183); fill-rule: nonzero; opacity: 1;"  transform=" translate(-40, -40)" d="M 60 40 L 80 80 L 40 80 L 0 80 L 20 40 L 40 0 L 60 40 z" stroke-linecap="round" />
+</g>
+<g transform="matrix(-2.8721265125 0 0 2.8721265125 291.2394541941 906.8016832619)" id="9XcEwsvwK0bmDyscpmiT_"  >
+<path style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(188,182,182); fill-rule: nonzero; opacity: 1;"  transform=" translate(-40, -40)" d="M 0 0 L 80 80 L 0 80 L 0 0 z" stroke-linecap="round" />
+</g>
+<g transform="matrix(2.8721265124 0 0 2.8721265124 732.7605458079 906.80168325)" id="OA_5HxecFF1yNHndTl_jk"  >
+<path style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(188,182,182); fill-rule: nonzero; opacity: 1;"  transform=" translate(-40, -40)" d="M 0 0 L 80 80 L 0 80 L 0 0 z" stroke-linecap="round" />
+</g>
+<g transform="matrix(6.1859273196 0 0 6.1859273196 512 711.0247142851)" id="6aPzOyzDFtKGRqBhSoE_9"  >
+<path style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(216,207,207); fill-rule: nonzero; opacity: 1;"  transform=" translate(-40, -40)" d="M 60 40 L 80 80 L 40 80 L 0 80 L 20 40 L 40 0 L 60 40 z" stroke-linecap="round" />
+</g>
+<g transform="matrix(10.305905974 0 0 10.305905974 512 339.6309735969)" id="8kf0UDbpjfbXZJW-ZQdx8"  >
+<radialGradient id="SVGID_344" gradientUnits="userSpaceOnUse" gradientTransform="matrix(1 0 0 1 -32.7076212817 -32.7076212817)"  cx="32.707622096865" cy="32.7076220968651" r="32.707622096865" fx="32.707622096865" fy="32.7076220968651">
+<stop offset="0%" style="stop-color:#BEBEBE;stop-opacity: 1"/>
+<stop offset="49.5652176962049%" style="stop-color:#A7A1A1;stop-opacity: 1"/>
+<stop offset="100%" style="stop-color:#CAC8C8;stop-opacity: 1"/>
+</radialGradient>
+<path style="stroke: rgb(118,29,179); stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: url(#SVGID_344); fill-rule: nonzero; opacity: 1;"  transform=" translate(0, 0)" d="M 0 -32.70762 C 18.05461 -32.70762 32.70762 -18.054609999999997 32.70762 0 C 32.70762 18.05461 18.054609999999997 32.70762 0 32.70762 C -18.05461 32.70762 -32.70762 18.054609999999997 -32.70762 0 C -32.70762 -18.05461 -18.054609999999997 -32.70762 0 -32.70762 z" stroke-linecap="round" />
+</g>
+<g transform="matrix(11.3139751844 0 0 11.3139751844 380.5507266288 304.1322198084)" id="9u0i6GVemKKzFVUjUHonL"  >
+<path style="stroke: rgb(233,253,144); stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(119,156,86); fill-rule: nonzero; opacity: 1;"  transform=" translate(0, 0)" d="M 0 -5.40386 C 2.98293 -5.40386 5.40386 -2.98293 5.40386 0 C 5.40386 2.98293 2.98293 5.40386 0 5.40386 C -2.98293 5.40386 -5.40386 2.98293 -5.40386 0 C -5.40386 -2.98293 -2.98293 -5.40386 0 -5.40386 z" stroke-linecap="round" />
+</g>
+<g transform="matrix(11.3139751844 0 0 11.3139751844 643.4492487982 304.1321952236)" id="o-krM9Y26TPlKk2KRD4_z"  >
+<path style="stroke: rgb(233,253,144); stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(119,156,86); fill-rule: nonzero; opacity: 1;"  transform=" translate(0, 0)" d="M 0 -5.40386 C 2.98293 -5.40386 5.40386 -2.98293 5.40386 0 C 5.40386 2.98293 2.98293 5.40386 0 5.40386 C -2.98293 5.40386 -5.40386 2.98293 -5.40386 0 C -5.40386 -2.98293 -2.98293 -5.40386 0 -5.40386 z" stroke-linecap="round" />
+</g>
+</svg>


### PR DESCRIPTION
- Added SVG library to handle SVG files
- Added new method to the UserService api to resolve avatar. For now it just takes default .svg file but in the future it will resolve ids of bought decorations and draw those decorations onto the base .svg.
- Refactored LayoutScreenAuthenticated to support new avatar.

Everything seems to work to some extent.
Note. If anyone is going to use avatar showcase, use Image component and not Icon component, since Icon makes image be of single solid color.