### PR TITLE
PVP-141

### DIFF
--- a/app/src/main/java/com/pvp/app/api/HealthConnectService.kt
+++ b/app/src/main/java/com/pvp/app/api/HealthConnectService.kt
@@ -6,15 +6,27 @@ import kotlin.reflect.KClass
 interface HealthConnectService {
 
     /**
+     * Reads all the data about a specified activity between the specified time range
      * @param record Specifies what kind of data needs to be read (steps, heart rate, etc.)
-     * @param start Specifies from what time should the data be read
-     * @param end Specifies until what time should the data be read
-     * @return Returns a list of activities the user has done during the timeframe
-     * and of the type specified
+     * @param start Specifies the start of time range
+     * @param end Specifies the end of the time range
+     * @return Returns a list of specified activity occurrences the user has
+     * participated in between the time range
      */
     suspend fun <T : Record> readActivityData(
         record: KClass<T>,
         start: java.time.Instant,
         end: java.time.Instant
     ): List<T>
+
+    /**
+     * Aggregates the steps between the specified time range
+     * @param start Specifies the start of time range
+     * @param end Specifies the end of the time range
+     * @return Returns the step count (0 if the data could not be read)
+     */
+    suspend fun aggregateSteps(
+        start: java.time.Instant,
+        end: java.time.Instant
+    ) : Long
 }

--- a/app/src/main/java/com/pvp/app/api/HealthConnectService.kt
+++ b/app/src/main/java/com/pvp/app/api/HealthConnectService.kt
@@ -28,5 +28,5 @@ interface HealthConnectService {
     suspend fun aggregateSteps(
         start: java.time.Instant,
         end: java.time.Instant
-    ) : Long
+    ): Long
 }

--- a/app/src/main/java/com/pvp/app/service/HealthConnectServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/HealthConnectServiceImpl.kt
@@ -30,17 +30,17 @@ class HealthConnectServiceImpl @Inject constructor(
     override suspend fun aggregateSteps(
         start: java.time.Instant,
         end: java.time.Instant
-    ) : Long {
-        return try{
+    ): Long {
+        return try {
             val response = client.aggregate(
                 AggregateRequest(
                     metrics = setOf(StepsRecord.COUNT_TOTAL),
-                    timeRangeFilter = TimeRangeFilter.between(start,  end)
+                    timeRangeFilter = TimeRangeFilter.between(start, end)
                 )
             )
 
             response[StepsRecord.COUNT_TOTAL] ?: 0L
-        } catch (e: Exception){
+        } catch (e: Exception) {
             0L
         }
     }

--- a/app/src/main/java/com/pvp/app/service/HealthConnectServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/HealthConnectServiceImpl.kt
@@ -2,6 +2,8 @@ package com.pvp.app.service
 
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
 import com.pvp.app.api.HealthConnectService
@@ -23,5 +25,23 @@ class HealthConnectServiceImpl @Inject constructor(
         )
 
         return client.readRecords(request).records
+    }
+
+    override suspend fun aggregateSteps(
+        start: java.time.Instant,
+        end: java.time.Instant
+    ) : Long {
+        return try{
+            val response = client.aggregate(
+                AggregateRequest(
+                    metrics = setOf(StepsRecord.COUNT_TOTAL),
+                    timeRangeFilter = TimeRangeFilter.between(start,  end)
+                )
+            )
+
+            response[StepsRecord.COUNT_TOTAL] ?: 0L
+        } catch (e: Exception){
+            0L
+        }
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
@@ -232,7 +232,6 @@ fun Day(
                     )
                 }
 
-                // Don't display steps if no date was supplied
                 if (!date.isEqual(LocalDate.MIN)) {
                     Text(
                         text = "Steps of the day",
@@ -318,13 +317,10 @@ fun StepCounter(
     val goal = 10000f // TODO create way for user to set a step goal?
     val progress = steps.value / goal
 
-
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier.fillMaxSize()
     ) {
-        // These have to be set here because for some reason MaterialTheme.colorScheme
-        // can't be used inside a Canvas ¯\_(ツ)_/¯
         val backgroundArcColor = MaterialTheme.colorScheme.primaryContainer
         val progressArcColor = MaterialTheme.colorScheme.primary
 
@@ -344,7 +340,10 @@ fun StepCounter(
                 useCenter = false,
                 topLeft = topLeft,
                 size = size,
-                style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+                style = Stroke(
+                    width = strokeWidth,
+                    cap = StrokeCap.Round
+                )
             )
 
             drawArc(
@@ -354,9 +353,13 @@ fun StepCounter(
                 useCenter = false,
                 topLeft = topLeft,
                 size = size,
-                style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+                style = Stroke(
+                    width = strokeWidth,
+                    cap = StrokeCap.Round
+                )
             )
         }
+
         Text(
             text = "${steps.value}",
             style = MaterialTheme.typography.titleSmall,

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.annotation.RequiresApi
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -41,7 +42,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -197,8 +202,8 @@ fun Day(
             modifier = Modifier
                 .background(MaterialTheme.colorScheme.surface)
                 .size(
-                    height = 200.dp,
-                    width = 200.dp
+                    height = 250.dp,
+                    width = 300.dp
                 )
                 .border(
                     BorderStroke(
@@ -218,40 +223,33 @@ fun Day(
                 Box(
                     modifier = Modifier
                         .background(MaterialTheme.colorScheme.secondaryContainer)
-                        .height(50.dp)
+                        .height(60.dp)
                         .fillMaxWidth()
                         .clickable { expand = !expand }
                 ) {
                     Text(
-                        name,
+                        text = name,
                         textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.titleLarge,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(16.dp)
                     )
                 }
 
-                // Don't display date and steps if no date was supplied
+                // Don't display steps if no date was supplied
                 if (!date.isEqual(LocalDate.MIN)) {
                     Text(
-                        "Steps",
+                        text = "Steps of the day",
                         textAlign = TextAlign.Center,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(8.dp)
-                    )
-
-                    StepCounter(date = date)
-
-                    Spacer(modifier = Modifier.weight(1f))
-
-                    Text(
-                        date.toString(),
-                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.titleSmall,
+                        fontSize = 20.sp,
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(16.dp)
                     )
+
+                    StepCounter(date = date)
                 }
             }
         }
@@ -322,12 +320,55 @@ fun StepCounter(
     }
 
     val steps = model.stepsCount.collectAsStateWithLifecycle()
+    val goal = 10000f // TODO create way for user to set a step goal?
+    val progress = steps.value / goal
 
-    Text(
-        steps.value.toString(),
-        textAlign = TextAlign.Center,
-        modifier = Modifier.fillMaxWidth()
-    )
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier.fillMaxSize()
+    ) {
+        // These have to be set here because for some reason MaterialTheme.colorScheme
+        // can't be used inside a Canvas ¯\_(ツ)_/¯
+        val backgroundArcColor = MaterialTheme.colorScheme.primaryContainer
+        val progressArcColor = MaterialTheme.colorScheme.primary
+
+        Canvas(modifier = Modifier.size(100.dp)) {
+            val strokeWidth = 6.dp.toPx()
+            val radius = 300f
+            val topLeft = Offset(
+                (size.width / 2) - (radius / 2),
+                (size.height / 2) - (radius / 2)
+            )
+            val size = Size(radius, radius)
+
+            drawArc(
+                color = backgroundArcColor,
+                startAngle = -90f,
+                sweepAngle = 360f,
+                useCenter = false,
+                topLeft = topLeft,
+                size = size,
+                style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+            )
+
+            drawArc(
+                color = progressArcColor,
+                startAngle = -90f,
+                sweepAngle = 360f * progress,
+                useCenter = false,
+                topLeft = topLeft,
+                size = size,
+                style = Stroke(width = strokeWidth, cap = StrokeCap.Round)
+            )
+        }
+        Text(
+            text = "${steps.value}",
+            style = MaterialTheme.typography.titleSmall,
+            fontSize = 20.sp,
+            textAlign = TextAlign.Center
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
@@ -232,7 +232,7 @@ fun Day(
                     )
                 }
 
-                if (!date.isEqual(LocalDate.MIN)) {
+                if (!date.isEqual(LocalDate.MIN) && !date.isAfter(LocalDate.now())) {
                     Text(
                         text = "Steps of the day",
                         textAlign = TextAlign.Center,

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
@@ -1,8 +1,6 @@
 package com.pvp.app.ui.screen.calendar
 
-import android.os.Build
 import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.annotation.RequiresApi
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
@@ -26,8 +24,6 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.DirectionsWalk
-import androidx.compose.material.icons.outlined.DirectionsWalk
 import androidx.compose.material.icons.outlined.Place
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -60,7 +56,6 @@ import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
 import com.pvp.app.ui.common.Button
-import com.pvp.app.ui.screen.steps.StepViewModel
 import com.pvp.app.ui.screen.task.CreateTaskGeneralForm
 import com.pvp.app.ui.screen.task.CreateTaskMealForm
 import com.pvp.app.ui.screen.task.CreateTaskSportForm

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarViewModel.kt
@@ -1,7 +1,15 @@
 package com.pvp.app.ui.screen.calendar
 
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.health.connect.client.HealthConnectClient
+import androidx.health.connect.client.permission.HealthPermission
+import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.records.StepsRecord
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.pvp.app.api.HealthConnectService
 import com.pvp.app.api.TaskService
 import com.pvp.app.api.UserService
 import com.pvp.app.model.Task
@@ -16,7 +24,10 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.Instant
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.ZoneId
 import java.time.temporal.IsoFields
 import javax.inject.Inject
 
@@ -24,11 +35,17 @@ import javax.inject.Inject
 @OptIn(ExperimentalCoroutinesApi::class)
 class CalendarViewModel @Inject constructor(
     private val taskService: TaskService,
-    private val userService: UserService
+    private val userService: UserService,
+    private val healtConnectService: HealthConnectService,
+    private val client: HealthConnectClient
+
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(CalendarState())
     val state = _state.asStateFlow()
+
+    private val _stepsCount = MutableStateFlow(0L)
+    val stepsCount = _stepsCount.asStateFlow()
 
     init {
         viewModelScope.launch {
@@ -60,10 +77,30 @@ class CalendarViewModel @Inject constructor(
                 .launchIn(viewModelScope)
         }
     }
+
+    suspend fun permissionsGranted(): Boolean {
+        val granted = client.permissionController.getGrantedPermissions()
+
+        return granted.containsAll(PERMISSIONS)
+    }
+
+    fun getDaysSteps(date: LocalDate) {
+        viewModelScope.launch {
+            val end = date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant()
+            val start = date.atStartOfDay(ZoneId.systemDefault()).toInstant()
+
+            _stepsCount.value = healtConnectService.aggregateSteps(start, end)
+        }
+    }
 }
 
 data class CalendarState(
     val tasksMonth: List<Task> = listOf(),
     val tasksWeek: List<Task> = listOf(),
     val user: User? = null
+)
+
+val PERMISSIONS = setOf(
+    HealthPermission.getReadPermission(StepsRecord::class),
+    HealthPermission.getReadPermission(ExerciseSessionRecord::class)
 )

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarViewModel.kt
@@ -1,8 +1,5 @@
 package com.pvp.app.ui.screen.calendar
 
-import android.os.Build
-import android.util.Log
-import androidx.annotation.RequiresApi
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.ExerciseSessionRecord
@@ -24,7 +21,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.ZoneId

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarViewModel.kt
@@ -34,7 +34,6 @@ class CalendarViewModel @Inject constructor(
     private val userService: UserService,
     private val healtConnectService: HealthConnectService,
     private val client: HealthConnectClient
-
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(CalendarState())
@@ -82,8 +81,13 @@ class CalendarViewModel @Inject constructor(
 
     fun getDaysSteps(date: LocalDate) {
         viewModelScope.launch {
-            val end = date.plusDays(1).atStartOfDay(ZoneId.systemDefault()).toInstant()
-            val start = date.atStartOfDay(ZoneId.systemDefault()).toInstant()
+            val end = date
+                .plusDays(1)
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
+            val start = date
+                .atStartOfDay(ZoneId.systemDefault())
+                .toInstant()
 
             _stepsCount.value = healtConnectService.aggregateSteps(start, end)
         }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/MonthlyCalendarScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/MonthlyCalendarScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -23,11 +22,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.capitalize
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.toLowerCase
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/MonthlyCalendarScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/MonthlyCalendarScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
@@ -22,6 +23,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.capitalize
 import androidx.compose.ui.text.style.TextAlign
@@ -71,7 +73,7 @@ fun DayDialog(
 ) {
     Dialog(
         onDismissRequest = { onDismissRequest() },
-        properties = DialogProperties(usePlatformDefaultWidth = false)
+        properties = DialogProperties(usePlatformDefaultWidth = false),
     ) {
         Day(
             "${date.month.toString().toLowerCase().capitalize()} ${date.dayOfMonth}",


### PR DESCRIPTION
Added a step counter to the daily view.

- Step counter is displayed only if the Day composable is supplied by the date
- The step progress is displayed in a circle. The step goal is currently hardcoded as 10000. Later we might need to add a way to set a step goal?
- Added a new method inside HealthConnectService for aggregating steps (the old method was prone to duplicates inside the data, although I left it as it allows to read other types of data besides steps)
- Daily view box size was increased so that the step progress circle fits

This is how the step counter looks in dark mode:


![Screenshot_20240314_161726](https://github.com/PVP-K410/Calendar/assets/25864361/60184b2f-2e12-461b-bb62-ae665cd11757)
