### PR TITLE
PVP 179

### DIFF
--- a/app/src/main/java/com/pvp/app/api/PointService.kt
+++ b/app/src/main/java/com/pvp/app/api/PointService.kt
@@ -10,11 +10,13 @@ interface PointService {
      * the task. User status can also be taken into account, hence, [Task.userEmail] is required.
      *
      * @param task task to calculate points for
+     * @param increasePointYield Indicates whether the calculation should increase points for this task
      *
      * @return points of the task
      */
     suspend fun calculate(
-        task: Task
+        task: Task,
+        increasePointYield: Boolean = false
     ): Int
 
     /**

--- a/app/src/main/java/com/pvp/app/service/PointServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/PointServiceImpl.kt
@@ -26,6 +26,8 @@ class PointServiceImpl @Inject constructor(
     private val userService: UserService
 ) : PointService {
 
+    private val weeklyMultiplier = 2
+
     override suspend fun calculate(
         task: Task,
         increasePointYield: Boolean
@@ -197,6 +199,4 @@ class PointServiceImpl @Inject constructor(
             }
         }
     }
-
-    private val weeklyMultiplier = 2
 }

--- a/app/src/main/java/com/pvp/app/service/PointServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/PointServiceImpl.kt
@@ -101,11 +101,11 @@ class PointServiceImpl @Inject constructor(
 
         val multiplier = if (increasePointYield) weeklyMultiplier else 1
 
-        return when (cosh(ln(distance * ratio))) {
+        return multiplier * when (cosh(ln(distance * ratio))) {
             in 0.0..1.65 -> 1
             in 1.65..2.5 -> 2
             else -> 3
-        } * multiplier
+        }
     }
 
     private fun calculateDurationPoints(
@@ -120,13 +120,13 @@ class PointServiceImpl @Inject constructor(
 
         val multiplier = if (increasePointYield) weeklyMultiplier else 1
 
-        val result = when ((duration / 60.0) * ratio) {
+        val result = multiplier * when ((duration / 60.0) * ratio) {
             in 0.0..0.75 -> 1
             in 0.75..1.5 -> 2
             in 1.5..2.8 -> 3
             in 2.8..4.2 -> 4
             else -> 5
-        } * multiplier
+        }
 
         return minOf(
             result,

--- a/app/src/main/java/com/pvp/app/service/TaskServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/TaskServiceImpl.kt
@@ -184,7 +184,10 @@ class TaskServiceImpl @Inject constructor(
             isExpired = task.scheduledAt
                 .toLocalDate()
                 .isBefore(LocalDate.now()),
-            value = pointService.calculate(task)
+            value = pointService.calculate(
+                task = task,
+                increasePointYield = isWeekly(activity)
+            )
         )
 
         val reference = database
@@ -307,6 +310,12 @@ class TaskServiceImpl @Inject constructor(
                     .filter { it.exists() }
                     .mapNotNull { d -> d.data?.let { decodeByType(it) } }
             }
+    }
+
+    private suspend fun isWeekly(activity: SportActivity): Boolean{
+        return userService.user
+            .firstOrNull()?.weeklyActivities
+            ?.contains(activity) ?: false
     }
 
     override suspend fun remove(

--- a/app/src/main/java/com/pvp/app/service/TaskServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/TaskServiceImpl.kt
@@ -312,10 +312,11 @@ class TaskServiceImpl @Inject constructor(
             }
     }
 
-    private suspend fun isWeekly(activity: SportActivity): Boolean{
+    private suspend fun isWeekly(activity: SportActivity): Boolean {
         return userService.user
             .firstOrNull()?.weeklyActivities
-            ?.contains(activity) ?: false
+            ?.contains(activity)
+            ?: false
     }
 
     override suspend fun remove(

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
@@ -699,10 +699,8 @@ fun Week(
     val date = dates[statePager.currentPage]
     var stateShowCards by remember { mutableStateOf(false) }
 
-    val tasksFiltered = remember(tasks.size, date) {
-        tasks.filter { task ->
-            task.scheduledAt.toLocalDate() == date
-        }
+    val tasksFiltered = tasks.filter { task ->
+        task.scheduledAt.toLocalDate() == date
     }
 
     Column(

--- a/app/src/main/java/com/pvp/app/ui/screen/task/TaskScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/task/TaskScreen.kt
@@ -554,9 +554,7 @@ fun TaskBox(
     task: Task,
     model: TaskViewModel = hiltViewModel()
 ) {
-    var checked by remember {
-        mutableStateOf(task.isCompleted)
-    }
+    var checked = task.isCompleted
 
     Box(
         modifier = Modifier
@@ -572,7 +570,6 @@ fun TaskBox(
                 shape = RoundedCornerShape(10.dp)
             )
     ) {
-
         Column(
             modifier = Modifier.padding(
                 horizontal = 8.dp,


### PR DESCRIPTION
Increased yield of points when sports activity is users weekly activity (a multiplier is applied when calculating distance/duration points, currently set at 2)

Also added a hotfixes for:

- Crashing when trying to complete a newly created task
- Checkbox state of tasks being saved between days