### PR TITLE
Chore/health connect

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.health.READ_DISTANCE" />
     <uses-permission android:name="android.permission.health.READ_EXERCISE" />
+    <uses-permission android:name="android.permission.health.READ_HEART_RATE" />
     <uses-permission android:name="android.permission.health.READ_SLEEP" />
     <uses-permission android:name="android.permission.health.READ_STEPS" />
     <uses-permission android:name="android.permission.health.READ_TOTAL_CALORIES_BURNED" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,6 +8,7 @@
     <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.health.READ_DISTANCE" />
     <uses-permission android:name="android.permission.health.READ_EXERCISE" />
+    <uses-permission android:name="android.permission.health.READ_SLEEP" />
     <uses-permission android:name="android.permission.health.READ_STEPS" />
     <uses-permission android:name="android.permission.health.READ_TOTAL_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />

--- a/app/src/main/java/com/pvp/app/api/HealthConnectService.kt
+++ b/app/src/main/java/com/pvp/app/api/HealthConnectService.kt
@@ -82,7 +82,7 @@ interface HealthConnectService {
      * between the specified time range
      * @param start Specifies the start of time range
      * @param end Specifies the end of the time range
-     * @return Returns the average heart rate
+     * @return Returns the maximum heart rate
      */
     suspend fun getHeartRateMax(
         start: Instant,

--- a/app/src/main/java/com/pvp/app/api/HealthConnectService.kt
+++ b/app/src/main/java/com/pvp/app/api/HealthConnectService.kt
@@ -66,6 +66,42 @@ interface HealthConnectService {
     ): Double
 
     /**
+     * Calculates and returns users average heart rate
+     * between the specified time range
+     * @param start Specifies the start of time range
+     * @param end Specifies the end of the time range
+     * @return Returns the average heart rate
+     */
+    suspend fun getHeartRateAvg(
+        start: Instant,
+        end: Instant
+    ): Long
+
+    /**
+     * Finds and returns users maximum heart rate
+     * between the specified time range
+     * @param start Specifies the start of time range
+     * @param end Specifies the end of the time range
+     * @return Returns the average heart rate
+     */
+    suspend fun getHeartRateMax(
+        start: Instant,
+        end: Instant
+    ): Long
+
+    /**
+     * Finds and returns users minimum heart rate
+     * between the specified time range
+     * @param start Specifies the start of time range
+     * @param end Specifies the end of the time range
+     * @return Returns the minimum heart rate
+     */
+    suspend fun getHeartRateMin(
+        start: Instant,
+        end: Instant
+    ): Long
+
+    /**
      * Reads all the data about a specified activity between the specified time range
      * @param record Specifies what kind of data needs to be read (steps, heart rate, etc.)
      * @param start Specifies the start of time range

--- a/app/src/main/java/com/pvp/app/api/HealthConnectService.kt
+++ b/app/src/main/java/com/pvp/app/api/HealthConnectService.kt
@@ -1,6 +1,7 @@
 package com.pvp.app.api
 
 import androidx.health.connect.client.records.Record
+import java.time.Duration
 import java.time.Instant
 import kotlin.reflect.KClass
 
@@ -40,6 +41,17 @@ interface HealthConnectService {
         start: Instant,
         end: Instant
     ): Long
+
+    /**
+     * Aggregates sleep time between the specified time range
+     * @param start Specifies the start of time range
+     * @param end Specifies the end of the time range
+     * @return Returns sleep duration (Duration.ZERO if no entries were found)
+     */
+    suspend fun aggregateSleepDuration(
+        start: Instant,
+        end: Instant
+    ): Duration
 
     /**
      * Aggregates total count of calories the user has burned

--- a/app/src/main/java/com/pvp/app/service/HealthConnectServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/HealthConnectServiceImpl.kt
@@ -4,6 +4,7 @@ import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.aggregate.AggregateMetric
 import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
 import androidx.health.connect.client.records.DistanceRecord
+import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.Record
 import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.StepsRecord
@@ -96,6 +97,39 @@ class HealthConnectServiceImpl @Inject constructor(
             start = start,
             end = end
         ) as? Energy)?.inCalories ?: 0.0
+    }
+
+    override suspend fun getHeartRateAvg(
+        start: Instant,
+        end: Instant
+    ): Long {
+        return aggregate(
+            metric = HeartRateRecord.BPM_AVG,
+            start = start,
+            end = end
+        ) as? Long ?: 0L
+    }
+
+    override suspend fun getHeartRateMax(
+        start: Instant,
+        end: Instant
+    ): Long {
+        return aggregate(
+            metric = HeartRateRecord.BPM_MAX,
+            start = start,
+            end = end
+        ) as? Long ?: 0L
+    }
+
+    override suspend fun getHeartRateMin(
+        start: Instant,
+        end: Instant
+    ): Long {
+        return aggregate(
+            metric = HeartRateRecord.BPM_MIN,
+            start = start,
+            end = end
+        ) as? Long ?: 0L
     }
 
     override suspend fun <T : Record> readActivityData(

--- a/app/src/main/java/com/pvp/app/service/HealthConnectServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/HealthConnectServiceImpl.kt
@@ -1,19 +1,20 @@
 package com.pvp.app.service
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import androidx.health.connect.client.HealthConnectClient
 import androidx.health.connect.client.aggregate.AggregateMetric
-import androidx.health.connect.client.aggregate.AggregationResult
 import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
 import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.Record
+import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
 import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
+import androidx.health.connect.client.units.Energy
+import androidx.health.connect.client.units.Length
 import com.pvp.app.api.HealthConnectService
+import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 import kotlin.reflect.KClass
@@ -22,64 +23,11 @@ class HealthConnectServiceImpl @Inject constructor(
     private val client: HealthConnectClient
 ) : HealthConnectService {
 
-    @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-    override suspend fun aggregateActiveCalories(
-        start: Instant,
-        end: Instant
-    ): Double {
-        return result(
-            metric = ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL,
-            start = start,
-            end = end
-        )?.let { aggregationResult ->
-            aggregationResult[ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL]?.inCalories ?: 0.0
-        } ?: 0.0
-    }
-
-    override suspend fun aggregateDistance(
-        start: Instant,
-        end: Instant
-    ): Double {
-        return result(
-            metric = DistanceRecord.DISTANCE_TOTAL,
-            start = start,
-            end = end
-        )?.let { result ->
-            result[DistanceRecord.DISTANCE_TOTAL]?.inMeters ?: 0.0
-        } ?: 0.0
-    }
-
-    override suspend fun aggregateSteps(
-        start: Instant,
-        end: Instant
-    ): Long {
-        return result(
-            metric = StepsRecord.COUNT_TOTAL,
-            start = start,
-            end = end
-        )?.let { aggregationResult ->
-            aggregationResult[StepsRecord.COUNT_TOTAL]
-        } ?: 0L
-    }
-
-    override suspend fun aggregateTotalCalories(
-        start: Instant,
-        end: Instant
-    ): Double {
-        return result(
-            metric = TotalCaloriesBurnedRecord.ENERGY_TOTAL,
-            start = start,
-            end = end
-        )?.let { aggregationResult ->
-            aggregationResult[TotalCaloriesBurnedRecord.ENERGY_TOTAL]?.inCalories ?: 0.0
-        } ?: 0.0
-    }
-
-    private suspend fun result(
+    private suspend fun aggregate(
         metric: AggregateMetric<*>,
         start: Instant,
         end: Instant
-    ): AggregationResult? {
+    ): Any? {
         return try {
             client.aggregate(
                 AggregateRequest(
@@ -89,10 +37,65 @@ class HealthConnectServiceImpl @Inject constructor(
                         end
                     )
                 )
-            )
+            )[metric]
         } catch (e: Exception) {
             null
         }
+    }
+
+    override suspend fun aggregateActiveCalories(
+        start: Instant,
+        end: Instant
+    ): Double {
+        return (aggregate(
+            metric = ActiveCaloriesBurnedRecord.ACTIVE_CALORIES_TOTAL,
+            start = start,
+            end = end
+        ) as? Energy)?.inCalories ?: 0.0
+    }
+
+    override suspend fun aggregateDistance(
+        start: Instant,
+        end: Instant
+    ): Double {
+        return (aggregate(
+            metric = DistanceRecord.DISTANCE_TOTAL,
+            start = start,
+            end = end
+        ) as? Length)?.inMeters ?: 0.0
+    }
+
+    override suspend fun aggregateSleepDuration(
+        start: Instant,
+        end: Instant
+    ): Duration {
+        return aggregate(
+            metric = SleepSessionRecord.SLEEP_DURATION_TOTAL,
+            start = start,
+            end = end
+        ) as? Duration ?: Duration.ZERO
+    }
+
+    override suspend fun aggregateSteps(
+        start: Instant,
+        end: Instant
+    ): Long {
+        return aggregate(
+            metric = StepsRecord.COUNT_TOTAL,
+            start = start,
+            end = end
+        ) as? Long ?: 0L
+    }
+
+    override suspend fun aggregateTotalCalories(
+        start: Instant,
+        end: Instant
+    ): Double {
+        return (aggregate(
+            metric = TotalCaloriesBurnedRecord.ENERGY_TOTAL,
+            start = start,
+            end = end
+        ) as? Energy)?.inCalories ?: 0.0
     }
 
     override suspend fun <T : Record> readActivityData(

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
@@ -126,22 +126,7 @@ fun CalorieCounter(
             TotalCaloriesBurnedRecord::class
         )
     )
-//    var launcherTriggered by remember { mutableStateOf(false) }
-//    val permissionContract = PermissionController.createRequestPermissionResultContract()
-//
-//    val launcher =
-//        rememberLauncherForActivityResult(permissionContract) {
-//            launcherTriggered = !launcherTriggered
-//        }
-//
-//    LaunchedEffect(date, launcherTriggered) {
-//        if (model.permissionsGranted()) {
-//            calories = model.getDaysCaloriesTotal(date)
-//        } else {
-//            launcher.launch(PERMISSIONS)
-//        }
-//    }
-////
+
     LaunchedEffect(date, permissionState.status) {
         calories = model.getDaysCaloriesTotal(date)
     }
@@ -322,6 +307,37 @@ fun Day(
     }
 }
 
+@OptIn(ExperimentalPermissionsApi::class)
+@Composable
+fun HeartRateCounterAverage(
+    model: CalendarWeeklyViewModel = hiltViewModel(),
+    date: LocalDate
+) {
+    var heartRate by remember { mutableLongStateOf(0L) }
+    val permissionState = rememberPermissionState(
+        permission = HealthPermission.getReadPermission(
+            TotalCaloriesBurnedRecord::class
+        )
+    )
+
+    LaunchedEffect(date, permissionState.status) {
+        heartRate = model.getDaysHeartRateAverage(date)
+    }
+
+    Icon(
+        imageVector = Icons.Outlined.MonitorHeart,
+        contentDescription = null,
+        modifier = Modifier.size(26.dp)
+    )
+
+    Text(
+        text = if (heartRate > 0) "$heartRate" else "-",
+        style = MaterialTheme.typography.titleSmall,
+        modifier = Modifier.padding(start = 8.dp)
+    )
+}
+
+
 @Composable
 fun ActivitiesBox(
     date: LocalDate,
@@ -424,17 +440,7 @@ fun ActivitiesBox(
                     }
 
                     ActivityRow {
-                        Icon(
-                            imageVector = Icons.Outlined.MonitorHeart,
-                            contentDescription = null,
-                            modifier = Modifier.size(26.dp)
-                        )
-
-                        Text(
-                            text = "0",
-                            style = MaterialTheme.typography.titleSmall,
-                            modifier = Modifier.padding(start = 8.dp)
-                        )
+                        HeartRateCounterAverage(date = date)
                     }
 
                     ActivityRow {
@@ -556,14 +562,8 @@ fun SleepDurationCounter(
         modifier = Modifier.size(26.dp)
     )
 
-    var text = "- hr - m"
-
-    if (!duration.equals(Duration.ZERO)) {
-        text = getDurationString(duration)
-    }
-
     Text(
-        text = text,
+        text = if (!duration.equals(Duration.ZERO)) getDurationString(duration) else "- hr - m",
         style = MaterialTheme.typography.titleSmall,
         modifier = Modifier.padding(start = 8.dp)
     )

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
@@ -121,14 +121,18 @@ fun CalorieCounter(
     date: LocalDate
 ) {
     var calories by remember { mutableDoubleStateOf(0.0) }
+
     val permissionState = rememberPermissionState(
         permission = HealthPermission.getReadPermission(
             TotalCaloriesBurnedRecord::class
         )
     )
 
-    LaunchedEffect(date, permissionState.status) {
-        calories = model.getDaysCaloriesTotal(date)
+    LaunchedEffect(
+        date,
+        permissionState.status
+    ) {
+        calories = model.getDayCaloriesTotal(date)
     }
 
     Icon(
@@ -314,14 +318,18 @@ fun HeartRateCounterAverage(
     date: LocalDate
 ) {
     var heartRate by remember { mutableLongStateOf(0L) }
+
     val permissionState = rememberPermissionState(
         permission = HealthPermission.getReadPermission(
             TotalCaloriesBurnedRecord::class
         )
     )
 
-    LaunchedEffect(date, permissionState.status) {
-        heartRate = model.getDaysHeartRateAverage(date)
+    LaunchedEffect(
+        date,
+        permissionState.status
+    ) {
+        heartRate = model.getDayHeartRateAverage(date)
     }
 
     Icon(
@@ -355,7 +363,10 @@ fun ActivitiesBox(
             launcherTriggered = !launcherTriggered
         }
 
-    LaunchedEffect(date, launcherTriggered) {
+    LaunchedEffect(
+        date,
+        launcherTriggered
+    ) {
         if (!model.permissionsGranted()) {
             launcher.launch(PERMISSIONS)
         }
@@ -546,14 +557,18 @@ fun SleepDurationCounter(
     date: LocalDate
 ) {
     var duration by remember { mutableStateOf(Duration.ZERO) }
+
     val permissionState = rememberPermissionState(
         permission = HealthPermission.getReadPermission(
             SleepSessionRecord::class
         )
     )
 
-    LaunchedEffect(date, permissionState.status) {
-        duration = model.getDaysSleepDuration(date)
+    LaunchedEffect(
+        date,
+        permissionState.status
+    ) {
+        duration = model.getDaySleepDuration(date)
     }
 
     Icon(
@@ -576,13 +591,17 @@ fun StepCounter(
     date: LocalDate
 ) {
     var steps by remember { mutableLongStateOf(0L) }
+
     val permissionState = rememberPermissionState(
         permission = HealthPermission.getReadPermission(
             StepsRecord::class
         )
     )
 
-    LaunchedEffect(date, permissionState.status) {
+    LaunchedEffect(
+        date,
+        permissionState.status
+    ) {
         steps = model.getDaysSteps(date)
     }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyViewModel.kt
@@ -5,6 +5,7 @@ import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
 import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
 import androidx.lifecycle.ViewModel
@@ -24,6 +25,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.time.Duration
 import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -107,6 +109,21 @@ class CalendarWeeklyViewModel @Inject constructor(
         )
     }
 
+    suspend fun getDaysSleepDuration(date: LocalDate): Duration {
+        val end = date
+            .plusDays(1)
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant()
+        val start = date
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant()
+
+        return healthConnectService.aggregateSleepDuration(
+            start,
+            end
+        )
+    }
+
     suspend fun getDaysSteps(date: LocalDate): Long {
         val end = date
             .plusDays(1)
@@ -149,6 +166,7 @@ val PERMISSIONS = setOf(
     HealthPermission.getReadPermission(ActiveCaloriesBurnedRecord::class),
     HealthPermission.getReadPermission(DistanceRecord::class),
     HealthPermission.getReadPermission(ExerciseSessionRecord::class),
+    HealthPermission.getReadPermission(SleepSessionRecord::class),
     HealthPermission.getReadPermission(StepsRecord::class),
     HealthPermission.getReadPermission(TotalCaloriesBurnedRecord::class)
 )

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyViewModel.kt
@@ -5,6 +5,7 @@ import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.ActiveCaloriesBurnedRecord
 import androidx.health.connect.client.records.DistanceRecord
 import androidx.health.connect.client.records.ExerciseSessionRecord
+import androidx.health.connect.client.records.HeartRateRecord
 import androidx.health.connect.client.records.SleepSessionRecord
 import androidx.health.connect.client.records.StepsRecord
 import androidx.health.connect.client.records.TotalCaloriesBurnedRecord
@@ -109,6 +110,19 @@ class CalendarWeeklyViewModel @Inject constructor(
         )
     }
 
+    suspend fun getDaysHeartRateAverage(date: LocalDate): Long {
+        val end = getEndInstant(date)
+
+        val start = date
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant()
+
+        return healthConnectService.getHeartRateAvg(
+            start,
+            end
+        )
+    }
+
     suspend fun getDaysSleepDuration(date: LocalDate): Duration {
         val end = date
             .plusDays(1)
@@ -166,6 +180,7 @@ val PERMISSIONS = setOf(
     HealthPermission.getReadPermission(ActiveCaloriesBurnedRecord::class),
     HealthPermission.getReadPermission(DistanceRecord::class),
     HealthPermission.getReadPermission(ExerciseSessionRecord::class),
+    HealthPermission.getReadPermission(HeartRateRecord::class),
     HealthPermission.getReadPermission(SleepSessionRecord::class),
     HealthPermission.getReadPermission(StepsRecord::class),
     HealthPermission.getReadPermission(TotalCaloriesBurnedRecord::class)

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyViewModel.kt
@@ -84,7 +84,7 @@ class CalendarWeeklyViewModel @Inject constructor(
         return granted.containsAll(PERMISSIONS)
     }
 
-    suspend fun getDaysCaloriesActive(date: LocalDate): Double {
+    suspend fun getDayCaloriesActive(date: LocalDate): Double {
         val end = getEndInstant(date)
 
         val start = date
@@ -97,7 +97,7 @@ class CalendarWeeklyViewModel @Inject constructor(
         )
     }
 
-    suspend fun getDaysCaloriesTotal(date: LocalDate): Double {
+    suspend fun getDayCaloriesTotal(date: LocalDate): Double {
         val end = getEndInstant(date)
 
         val start = date
@@ -110,7 +110,7 @@ class CalendarWeeklyViewModel @Inject constructor(
         )
     }
 
-    suspend fun getDaysHeartRateAverage(date: LocalDate): Long {
+    suspend fun getDayHeartRateAverage(date: LocalDate): Long {
         val end = getEndInstant(date)
 
         val start = date
@@ -123,11 +123,12 @@ class CalendarWeeklyViewModel @Inject constructor(
         )
     }
 
-    suspend fun getDaysSleepDuration(date: LocalDate): Duration {
+    suspend fun getDaySleepDuration(date: LocalDate): Duration {
         val end = date
             .plusDays(1)
             .atStartOfDay(ZoneId.systemDefault())
             .toInstant()
+
         val start = date
             .atStartOfDay(ZoneId.systemDefault())
             .toInstant()
@@ -143,6 +144,7 @@ class CalendarWeeklyViewModel @Inject constructor(
             .plusDays(1)
             .atStartOfDay(ZoneId.systemDefault())
             .toInstant()
+
         val start = date
             .atStartOfDay(ZoneId.systemDefault())
             .toInstant()


### PR DESCRIPTION
- Added sleep and heart rate data reading from health connect. This data is used in ActivitiesBox as HeartRateCounterAverage and SleepDurationCounter
- Moved permission launcher from each counter (sleep, calories) to the Activities Box. Counters remember permission state and update when permission status changes.