### PR TITLE
PVP-203 Improve header look

### DIFF
--- a/app/src/main/java/com/pvp/app/ui/router/Router.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Router.kt
@@ -31,7 +31,6 @@ fun Router(
                 animationSpec = tween(500)
             )
         },
-        modifier = modifier,
         navController = controller,
         startDestination = destinationStart.path
     ) {
@@ -39,6 +38,7 @@ fun Router(
             composable(route = r.path) {
                 r.screen(
                     controller,
+                    modifier,
                     scope
                 )
             }

--- a/app/src/main/java/com/pvp/app/ui/router/Routes.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Routes.kt
@@ -8,6 +8,7 @@ import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Storefront
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.navigation.NavHostController
 import com.pvp.app.R
@@ -25,7 +26,7 @@ sealed class Route(
     val iconDescription: String? = null,
     val path: String,
     val resourceTitleId: Int,
-    val screen: @Composable (NavHostController, CoroutineScope) -> Unit
+    val screen: @Composable (NavHostController, Modifier, CoroutineScope) -> Unit
 ) {
 
     companion object {
@@ -77,7 +78,7 @@ sealed class Route(
     data object Authentication : Route(
         path = "authentication",
         resourceTitleId = R.string.empty,
-        screen = { _, _ -> AuthenticationScreen() }
+        screen = { _, _, _ -> AuthenticationScreen() }
     )
 
     data object Calendar : Route(
@@ -85,7 +86,7 @@ sealed class Route(
         iconDescription = "Calendar page button icon",
         path = "calendar",
         resourceTitleId = R.string.route_calendar,
-        screen = { _, _ -> CalendarScreen() }
+        screen = { _, m, _ -> CalendarScreen(modifier = m) }
     )
 
     data object Decorations : Route(
@@ -93,7 +94,7 @@ sealed class Route(
         iconDescription = "Decorations page button icon",
         path = "decorations",
         resourceTitleId = R.string.route_decorations,
-        screen = { _, _ -> DecorationScreen() }
+        screen = { _, m, _ -> DecorationScreen(modifier = m) }
     )
 
     data object Friends : Route(
@@ -101,13 +102,13 @@ sealed class Route(
         iconDescription = "Friends page button icon",
         path = "friends",
         resourceTitleId = R.string.route_friends,
-        screen = { _, _ -> FriendsScreen() }
+        screen = { _, m, _ -> FriendsScreen(modifier = m) }
     )
 
     data object None : Route(
         path = "none",
         resourceTitleId = R.string.empty,
-        screen = { _, _ -> }
+        screen = { _, _, _ -> }
     )
 
     data object Settings : Route(
@@ -115,7 +116,7 @@ sealed class Route(
         iconDescription = "Settings page button icon",
         path = "settings",
         resourceTitleId = R.string.route_settings,
-        screen = { _, _ -> SettingsScreen() }
+        screen = { _, m, _ -> SettingsScreen(modifier = m) }
     )
 
     @SuppressLint("NewApi")
@@ -124,12 +125,12 @@ sealed class Route(
         iconDescription = "Step counter page button icon",
         path = "steps",
         resourceTitleId = R.string.route_steps,
-        screen = { _, _ -> StepScreen() }
+        screen = { _, m, _ -> StepScreen(modifier = m) }
     )
 
     data object Survey : Route(
         path = "survey",
         resourceTitleId = R.string.route_survey,
-        screen = { _, _ -> SurveyScreen() }
+        screen = { _, _, _ -> SurveyScreen() }
     )
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarMonthlyScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarMonthlyScreen.kt
@@ -153,6 +153,7 @@ private fun CalendarMonthly(
     dates: List<CalendarUiState.DateEntry>,
     days: Array<String>,
     expand: Boolean,
+    modifier: Modifier,
     month: YearMonth,
     onChangeExpand: (Boolean) -> Unit,
     onChangeShowAnalyses: (Boolean) -> Unit,
@@ -163,7 +164,7 @@ private fun CalendarMonthly(
     tasks: List<Task>
 ) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .padding(16.dp)
     ) {
@@ -292,7 +293,10 @@ private fun CalendarMonthlyContentItem(
 }
 
 @Composable
-fun CalendarMonthlyScreen(model: CalendarMonthlyViewModel = hiltViewModel()) {
+fun CalendarMonthlyScreen(
+    model: CalendarMonthlyViewModel = hiltViewModel(),
+    modifier: Modifier
+) {
     var date by remember { mutableStateOf(LocalDate.now()) }
     var expand by remember { mutableStateOf(false) }
     var showAnalyses by remember { mutableStateOf(false) }
@@ -305,6 +309,7 @@ fun CalendarMonthlyScreen(model: CalendarMonthlyViewModel = hiltViewModel()) {
         dates = state.dates,
         days = DateUtil.daysOfWeek,
         expand = expand,
+        modifier = modifier,
         month = state.yearMonth,
         onChangeExpand = { expand = it },
         onChangeShowAnalyses = { showAnalyses = it },

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
@@ -1,7 +1,6 @@
 package com.pvp.app.ui.screen.calendar
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
@@ -9,19 +8,16 @@ import androidx.compose.ui.Modifier
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun CalendarScreen() {
+fun CalendarScreen(modifier: Modifier) {
     val state = rememberPagerState(
         pageCount = { 2 },
         initialPage = 1
     )
 
-    VerticalPager(
-        state = state,
-        modifier = Modifier.fillMaxSize()
-    ) { page ->
+    VerticalPager(state = state) { page ->
         when (page) {
-            0 -> CalendarMonthlyScreen()
-            1 -> CalendarWeeklyScreen()
+            0 -> CalendarMonthlyScreen(modifier = modifier)
+            1 -> CalendarWeeklyScreen(modifier = modifier)
         }
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -27,10 +26,13 @@ import java.time.LocalDate
 import java.time.temporal.TemporalAdjusters
 
 @Composable
-fun CalendarWeeklyScreen(model: CalendarWeeklyViewModel = hiltViewModel()) {
+fun CalendarWeeklyScreen(
+    model: CalendarWeeklyViewModel = hiltViewModel(),
+    modifier: Modifier
+) {
     val state by model.state.collectAsStateWithLifecycle()
 
-    Column(modifier = Modifier.fillMaxSize()) { Week(tasks = state.tasks) }
+    Column(modifier = modifier.fillMaxSize()) { Week(tasks = state.tasks) }
 }
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -74,8 +76,7 @@ fun Week(
                         scope.launch {
                             statePager.scrollToPage(page)
                         }
-                    }
-                    else {
+                    } else {
                         if (tasksFiltered.isEmpty()) {
                             stateDialog = true
                         } else {

--- a/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -96,15 +96,15 @@ private fun Apply(model: DecorationViewModel = hiltViewModel()) {
 }
 
 @Composable
-fun DecorationScreen() {
+fun DecorationScreen(modifier: Modifier) {
     var screen by remember { mutableIntStateOf(0) }
 
     Column(
         modifier = Modifier
-            .background(MaterialTheme.colorScheme.background)
-            .fillMaxHeight()
-            .fillMaxWidth()
             .verticalScroll(rememberScrollState())
+            .then(modifier)
+            .fillMaxSize()
+            .background(MaterialTheme.colorScheme.background)
     ) {
         Spacer(modifier = Modifier.size(16.dp))
 

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendsScreen.kt
@@ -61,7 +61,8 @@ private enum class SortingType {
 
 @Composable
 fun FriendsScreen(
-    model: FriendsViewModel = hiltViewModel()
+    model: FriendsViewModel = hiltViewModel(),
+    modifier: Modifier
 ) {
     val context = LocalContext.current
     val toastMessage by model.toastMessage
@@ -98,7 +99,7 @@ fun FriendsScreen(
     }
 
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .padding(
                 start = 16.dp,

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
@@ -12,11 +12,13 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
@@ -162,23 +164,29 @@ private fun toggleNavigationDrawer(
 @Composable
 private fun Content(
     controller: NavHostController,
-    modifier: Modifier = Modifier,
+    paddingValues: PaddingValues,
     scope: CoroutineScope,
     state: PagerState
 ) {
-    HorizontalPager(
-        modifier = modifier,
-        state = state
-    ) {
+    val modifier = remember(paddingValues) {
+        val padding = paddingValues.calculateTopPadding()
+
+        Modifier
+            .offset(y = padding)
+            .padding(bottom = padding)
+    }
+
+    HorizontalPager(state = state) {
         when (it) {
             0 -> Router(
                 controller = controller,
                 destinationStart = Route.Calendar,
+                modifier = modifier,
                 routes = Route.routesAuthenticated,
                 scope = scope
             )
 
-            1 -> ProfileScreen()
+            1 -> ProfileScreen(modifier = modifier)
         }
     }
 }
@@ -361,7 +369,7 @@ fun LayoutScreenAuthenticated(
         ) {
             Content(
                 controller = controller,
-                modifier = Modifier.padding(it),
+                paddingValues = it,
                 scope = scope,
                 state = statePager
             )

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenUnauthenticated.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenUnauthenticated.kt
@@ -18,9 +18,7 @@ fun LayoutScreenUnauthenticated(
     isAuthenticated: Boolean,
     scope: CoroutineScope
 ) {
-    Surface(
-        modifier = Modifier.fillMaxSize()
-    ) {
+    Surface(modifier = Modifier.fillMaxSize()) {
         Router(
             controller = controller,
             destinationStart = if (isAuthenticated && areSurveysFilled == false) {

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
@@ -305,6 +305,7 @@ private fun BoxScope.Points(
 
 @Composable
 fun ProfileScreen(
+    modifier: Modifier,
     viewModel: ProfileViewModel = hiltViewModel()
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
@@ -316,13 +317,13 @@ fun ProfileScreen(
     }
 
     Box(
-        modifier = Modifier.verticalScroll(rememberScrollState())
+        modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .then(modifier)
     ) {
         Points(points = state.user.points)
 
-        Column(
-            modifier = Modifier.fillMaxWidth()
-        ) {
+        Column(modifier = Modifier.fillMaxWidth()) {
             Initials(
                 onUsernameChange = {
                     viewModel.update { u -> u.username = it }

--- a/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
@@ -274,13 +274,15 @@ private fun SettingApplicationTheme(
 
 @Composable
 fun SettingsScreen(
-    model: SettingsViewModel = hiltViewModel()
+    model: SettingsViewModel = hiltViewModel(),
+    modifier: Modifier
 ) {
     Column(
         modifier = Modifier
+            .verticalScroll(rememberScrollState())
+            .then(modifier)
             .fillMaxSize()
             .padding(horizontal = 24.dp)
-            .verticalScroll(rememberScrollState())
     ) {
         CategoryRow(
             icon = Icons.Outlined.Notifications,

--- a/app/src/main/java/com/pvp/app/ui/screen/steps/StepScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/steps/StepScreen.kt
@@ -117,9 +117,9 @@ fun StepCounter(
  */
 @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
 @Composable
-fun StepScreen() {
+fun StepScreen(modifier: Modifier) {
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxSize()
             .background(MaterialTheme.colorScheme.surface)
             .padding(8.dp),


### PR DESCRIPTION
# Changes
- Added modifier with offset and bottom padding properties.
  - Modifier is delegated to every screen.
- Screens properties/components were modified to support new modifier.

VerticalScroll must be applied before this modifier, else padding (from before changes) appears.

![image](https://github.com/PVP-K410/Calendar/assets/73783588/f9bb39f8-28a1-48da-9f2c-babc8d6a0a26)
