### PR TITLE
PVP-253 Change decorations `Purchase` screen name to `Store`

### DIFF
--- a/app/src/main/java/com/pvp/app/ui/screen/decoration/Decoration.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/decoration/Decoration.kt
@@ -33,9 +33,9 @@ import com.pvp.app.ui.common.lighten
 
 @Composable
 private fun DecorationCard(
-    actionPurchase: Boolean,
     holder: DecorationHolder,
     isClickable: Boolean = true,
+    isStore: Boolean,
     onClick: () -> Unit
 ) {
     Row(
@@ -84,22 +84,24 @@ private fun DecorationCard(
                 textAlign = TextAlign.Justify
             )
 
-            if (actionPurchase && !holder.owned) {
-                Row(
-                    horizontalArrangement = Arrangement.Center,
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text(
-                        modifier = Modifier.padding(end = 4.dp),
-                        text = "${holder.decoration.price}"
-                    )
+            if (!isStore) {
+                return
+            }
 
-                    Icon(
-                        contentDescription = "Decoration ${holder.decoration.name} cost in points icon",
-                        imageVector = Icons.Outlined.Stars
-                    )
-                }
+            Row(
+                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(
+                    modifier = Modifier.padding(end = 4.dp),
+                    text = "${holder.decoration.price}"
+                )
+
+                Icon(
+                    contentDescription = "Decoration ${holder.decoration.name} cost in points icon",
+                    imageVector = Icons.Outlined.Stars
+                )
             }
         }
     }
@@ -107,9 +109,9 @@ private fun DecorationCard(
 
 @Composable
 fun DecorationCards(
-    actionPurchase: Boolean,
     holders: List<DecorationHolder>,
     isClickable: Boolean,
+    isStore: Boolean,
     onClick: (DecorationHolder) -> Unit
 ) {
     val holdersGrouped = remember(holders) { holders.groupBy { it.decoration.type } }
@@ -124,9 +126,9 @@ fun DecorationCards(
                 ) {
                     holdersGrouped.forEach { holder ->
                         DecorationCard(
-                            actionPurchase = actionPurchase,
                             holder = holder,
                             isClickable = isClickable,
+                            isStore = isStore,
                             onClick = { onClick(holder) }
                         )
                     }

--- a/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationScreen.kt
@@ -87,7 +87,7 @@ private fun Apply(model: DecorationViewModel = hiltViewModel()) {
             )
         } else {
             DecorationCards(
-                actionPurchase = false,
+                isStore = false,
                 holders = state.holders.filter { h -> h in holdersOwned },
                 isClickable = state.state is DecorationScreenState.NoOperation
             ) { model.apply(it.decoration) }
@@ -135,7 +135,7 @@ fun DecorationScreen(modifier: Modifier) {
 }
 
 @Composable
-private fun Purchase(model: DecorationViewModel = hiltViewModel()) {
+private fun Store(model: DecorationViewModel = hiltViewModel()) {
     var item by remember { mutableStateOf<DecorationHolder?>(null) }
     var showDialog by remember { mutableStateOf(false) }
     val state by model.state.collectAsStateWithLifecycle()
@@ -160,7 +160,7 @@ private fun Purchase(model: DecorationViewModel = hiltViewModel()) {
             )
         } else {
             DecorationCards(
-                actionPurchase = true,
+                isStore = true,
                 holders = state.holders.filter { h -> h !in holders },
                 isClickable = state.state is DecorationScreenState.NoOperation
             ) {
@@ -223,6 +223,6 @@ private fun Purchase(model: DecorationViewModel = hiltViewModel()) {
 
 @Composable
 private fun screens() = listOf<Pair<String, @Composable () -> Unit>>(
-    "Purchase" to { Purchase() },
+    "Store" to { Store() },
     "Owned" to { Apply() },
 )


### PR DESCRIPTION
# Changes
- Decorations `Purchase` screen renamed to `Store`
- Tab renamed from `Purchase` to `Store`
- Associated parameter in components renamed from `actionPurchase` to `isStore` to not misguide on functionalities
- Modified condition to show price, since decorations are filtered from above so no need to additionally check for `owned` state.