### PR TITLE
PVP-243: Add autocomplete indicator near tasks that are likely to be autocompleted

### DIFF
--- a/app/src/main/java/com/pvp/app/ui/common/Components.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Components.kt
@@ -4,7 +4,11 @@ import android.content.Context
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
+import androidx.compose.foundation.BasicTooltipBox
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -16,23 +20,30 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberBasicTooltipState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.ErrorOutline
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.KeyboardArrowDown
 import androidx.compose.material.icons.outlined.KeyboardArrowUp
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TooltipDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -52,6 +63,7 @@ import coil.compose.SubcomposeAsyncImageContent
 import coil.size.Size
 import coil.transform.Transformation
 import com.pvp.app.ui.common.ImageUtil.requestImage
+import kotlinx.coroutines.launch
 
 @Composable
 fun AsyncImage(
@@ -257,6 +269,48 @@ fun Experience(
                 style = progressTextStyle,
                 text = "$experience / $experienceRequired Exp",
                 textAlign = TextAlign.Center
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun InfoTooltip(
+    tooltipText: String
+) {
+    val tooltipState = rememberBasicTooltipState()
+    val scope = rememberCoroutineScope()
+
+    BasicTooltipBox(
+        positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
+        tooltip = {
+            Text(
+                text = tooltipText,
+                modifier = Modifier
+                    .clip(MaterialTheme.shapes.medium)
+                    .background(MaterialTheme.colorScheme.primary)
+                    .border(
+                        border = BorderStroke(
+                            1.dp,
+                            MaterialTheme.colorScheme.outline
+                        ),
+                        shape = MaterialTheme.shapes.medium,
+                    )
+                    .height(40.dp)
+                    .padding(8.dp)
+                    .wrapContentSize(Alignment.Center),
+                color = Color.White
+            )
+        },
+        state = tooltipState
+    ) {
+        IconButton(
+            onClick = { scope.launch { tooltipState.show() } },
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Info,
+                contentDescription = "Autocompletion of activity"
             )
         }
     }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
@@ -37,6 +37,7 @@ import com.pvp.app.common.DurationUtil.asString
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
+import com.pvp.app.ui.common.InfoTooltip
 import java.time.format.DateTimeFormatter
 
 @Composable
@@ -198,19 +199,24 @@ private fun TaskCardContentSport(task: SportTask) {
         }
     }
 
-    Row(modifier = Modifier.padding(6.dp)) {
+    Row(
+        modifier = Modifier.padding(6.dp),
+        verticalAlignment = CenterVertically
+    ) {
         Icon(
             contentDescription = "Activity",
             imageVector = task.activity.icon
         )
 
         Text(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(start = 8.dp),
+            modifier = Modifier.padding(start = 8.dp),
             text = task.activity.title,
             textAlign = TextAlign.Left
         )
+
+        if (task.activity.supportsDistanceMetrics) {
+            InfoTooltip(tooltipText = "This task is likely to be autocompleted")
+        }
     }
 }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
@@ -1,22 +1,42 @@
 package com.pvp.app.ui.screen.calendar
 
+import androidx.compose.foundation.BasicTooltipBox
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.rememberBasicTooltipState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.TooltipDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -28,9 +48,10 @@ import com.pvp.app.ui.common.EditableInfoItem
 import com.pvp.app.ui.common.LabelFieldWrapper
 import com.pvp.app.ui.common.PickerPair
 import com.pvp.app.ui.common.PickerState
+import kotlinx.coroutines.launch
 import java.time.Duration
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun TaskEditFieldsSport(
     task: SportTask? = null,
@@ -85,7 +106,61 @@ fun TaskEditFieldsSport(
         label = "Activity",
         onConfirm = { activity = tempActivity },
         onDismiss = { tempActivity = activity },
-        value = activity?.title ?: ""
+        value = {
+            Row (
+                Modifier
+                    .fillMaxWidth()
+                    .padding(0.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                val tooltipState = rememberBasicTooltipState()
+                val scope = rememberCoroutineScope()
+
+                Text(activity?.title ?: "")
+
+                if (activity?.supportsDistanceMetrics == true) {
+                    BasicTooltipBox(
+                        positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
+                        tooltip = {
+                            Column(
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Text(
+                                    text = "This task is likely to be autocompleted",
+                                    modifier = Modifier
+                                        .clip(RoundedCornerShape(10.dp))
+                                        .background(MaterialTheme.colorScheme.primary)
+                                        .size(
+                                            height = 40.dp,
+                                            width = 300.dp
+                                        )
+                                        .border(
+                                            border = BorderStroke(
+                                                1.dp,
+                                                MaterialTheme.colorScheme.outline
+                                            ),
+                                            shape = RoundedCornerShape(10.dp)
+                                        )
+                                        .wrapContentSize(Alignment.Center),
+                                    color = Color.White
+                                )
+                            }
+                        },
+                        state = tooltipState
+                    ) {
+                        IconButton(
+                            onClick = { scope.launch { tooltipState.show() } },
+                            modifier = Modifier.padding(0.dp)
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Info,
+                                contentDescription = ""
+                            )
+                        }
+                    }
+                }
+            }
+        }
     )
 
     if (activity != null && activity!!.supportsDistanceMetrics) {

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
@@ -8,13 +8,12 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberBasicTooltipState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
@@ -108,9 +107,7 @@ fun TaskEditFieldsSport(
         onDismiss = { tempActivity = activity },
         value = {
             Row (
-                Modifier
-                    .fillMaxWidth()
-                    .padding(0.dp),
+                Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 val tooltipState = rememberBasicTooltipState()
@@ -119,45 +116,39 @@ fun TaskEditFieldsSport(
                 Text(activity?.title ?: "")
 
                 if (activity?.supportsDistanceMetrics == true) {
-                    BasicTooltipBox(
+                    InfoTooltip(tooltipText = "This task is likely to be autocompleted")
+                    /*BasicTooltipBox(
                         positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
                         tooltip = {
-                            Column(
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                Text(
-                                    text = "This task is likely to be autocompleted",
-                                    modifier = Modifier
-                                        .clip(RoundedCornerShape(10.dp))
-                                        .background(MaterialTheme.colorScheme.primary)
-                                        .size(
-                                            height = 40.dp,
-                                            width = 300.dp
-                                        )
-                                        .border(
-                                            border = BorderStroke(
-                                                1.dp,
-                                                MaterialTheme.colorScheme.outline
-                                            ),
-                                            shape = RoundedCornerShape(10.dp)
-                                        )
-                                        .wrapContentSize(Alignment.Center),
-                                    color = Color.White
-                                )
-                            }
+                            Text(
+                                text = "This task is likely to be autocompleted",
+                                modifier = Modifier
+                                    .clip(MaterialTheme.shapes.medium)
+                                    .background(MaterialTheme.colorScheme.primary)
+                                    .border(
+                                        border = BorderStroke(
+                                            1.dp,
+                                            MaterialTheme.colorScheme.outline
+                                        ),
+                                        shape = MaterialTheme.shapes.medium,
+                                    )
+                                    .height(40.dp)
+                                    .padding(8.dp)
+                                    .wrapContentSize(Alignment.Center),
+                                color = Color.White
+                            )
                         },
                         state = tooltipState
                     ) {
                         IconButton(
                             onClick = { scope.launch { tooltipState.show() } },
-                            modifier = Modifier.padding(0.dp)
                         ) {
                             Icon(
-                                imageVector = Icons.Filled.Info,
-                                contentDescription = ""
+                                imageVector = Icons.Outlined.Info,
+                                contentDescription = "Tooltip about autocompletion of activity"
                             )
                         }
-                    }
+                    }*/
                 }
             }
         }
@@ -248,4 +239,46 @@ fun TaskEditFieldsSport(
     onDistanceChange(distance)
 
     duration?.let { onDurationChange(it) }
+}
+
+@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
+@Composable
+fun InfoTooltip(
+    tooltipText: String
+) {
+    val tooltipState = rememberBasicTooltipState()
+    val scope = rememberCoroutineScope()
+
+    BasicTooltipBox(
+        positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
+        tooltip = {
+            Text(
+                text = tooltipText,
+                modifier = Modifier
+                    .clip(MaterialTheme.shapes.medium)
+                    .background(MaterialTheme.colorScheme.primary)
+                    .border(
+                        border = BorderStroke(
+                            1.dp,
+                            MaterialTheme.colorScheme.outline
+                        ),
+                        shape = MaterialTheme.shapes.medium,
+                    )
+                    .height(40.dp)
+                    .padding(8.dp)
+                    .wrapContentSize(Alignment.Center),
+                color = Color.White
+            )
+        },
+        state = tooltipState
+    ) {
+        IconButton(
+            onClick = { scope.launch { tooltipState.show() } },
+        ) {
+            Icon(
+                imageVector = Icons.Outlined.Info,
+                contentDescription = "Autocompletion of activity"
+            )
+        }
+    }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
@@ -1,41 +1,24 @@
 package com.pvp.app.ui.screen.calendar
 
-import androidx.compose.foundation.BasicTooltipBox
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.background
-import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentSize
-import androidx.compose.foundation.rememberBasicTooltipState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ExposedDropdownMenuBox
 import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
-import androidx.compose.material3.TooltipDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -47,10 +30,10 @@ import com.pvp.app.ui.common.EditableInfoItem
 import com.pvp.app.ui.common.LabelFieldWrapper
 import com.pvp.app.ui.common.PickerPair
 import com.pvp.app.ui.common.PickerState
-import kotlinx.coroutines.launch
+import com.pvp.app.ui.common.InfoTooltip
 import java.time.Duration
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TaskEditFieldsSport(
     task: SportTask? = null,
@@ -110,45 +93,10 @@ fun TaskEditFieldsSport(
                 Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically
             ) {
-                val tooltipState = rememberBasicTooltipState()
-                val scope = rememberCoroutineScope()
-
                 Text(activity?.title ?: "")
 
                 if (activity?.supportsDistanceMetrics == true) {
                     InfoTooltip(tooltipText = "This task is likely to be autocompleted")
-                    /*BasicTooltipBox(
-                        positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
-                        tooltip = {
-                            Text(
-                                text = "This task is likely to be autocompleted",
-                                modifier = Modifier
-                                    .clip(MaterialTheme.shapes.medium)
-                                    .background(MaterialTheme.colorScheme.primary)
-                                    .border(
-                                        border = BorderStroke(
-                                            1.dp,
-                                            MaterialTheme.colorScheme.outline
-                                        ),
-                                        shape = MaterialTheme.shapes.medium,
-                                    )
-                                    .height(40.dp)
-                                    .padding(8.dp)
-                                    .wrapContentSize(Alignment.Center),
-                                color = Color.White
-                            )
-                        },
-                        state = tooltipState
-                    ) {
-                        IconButton(
-                            onClick = { scope.launch { tooltipState.show() } },
-                        ) {
-                            Icon(
-                                imageVector = Icons.Outlined.Info,
-                                contentDescription = "Tooltip about autocompletion of activity"
-                            )
-                        }
-                    }*/
                 }
             }
         }
@@ -239,46 +187,4 @@ fun TaskEditFieldsSport(
     onDistanceChange(distance)
 
     duration?.let { onDurationChange(it) }
-}
-
-@OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
-@Composable
-fun InfoTooltip(
-    tooltipText: String
-) {
-    val tooltipState = rememberBasicTooltipState()
-    val scope = rememberCoroutineScope()
-
-    BasicTooltipBox(
-        positionProvider = TooltipDefaults.rememberRichTooltipPositionProvider(),
-        tooltip = {
-            Text(
-                text = tooltipText,
-                modifier = Modifier
-                    .clip(MaterialTheme.shapes.medium)
-                    .background(MaterialTheme.colorScheme.primary)
-                    .border(
-                        border = BorderStroke(
-                            1.dp,
-                            MaterialTheme.colorScheme.outline
-                        ),
-                        shape = MaterialTheme.shapes.medium,
-                    )
-                    .height(40.dp)
-                    .padding(8.dp)
-                    .wrapContentSize(Alignment.Center),
-                color = Color.White
-            )
-        },
-        state = tooltipState
-    ) {
-        IconButton(
-            onClick = { scope.launch { tooltipState.show() } },
-        ) {
-            Icon(
-                imageVector = Icons.Outlined.Info,
-                contentDescription = "Autocompletion of activity"
-            )
-        }
-    }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
@@ -143,6 +143,7 @@ fun TaskCreateForm(
     var duration by remember { mutableStateOf(Duration.ofMinutes(0)) }
     var reminderTime by remember { mutableStateOf<Duration?>(null) }
     var activity by remember { mutableStateOf(SportActivity.Walking) }
+    var supportsDistanceMetrics by remember { mutableStateOf(false) }
     var distance by remember { mutableDoubleStateOf(0.0) }
     var dateTime by remember { mutableStateOf(date ?: LocalDateTime.now()) }
     var editingTitle by remember { mutableStateOf("") }
@@ -223,6 +224,7 @@ fun TaskCreateForm(
                     onActivityChange = { newActivity ->
                         if (newActivity != null) {
                             activity = newActivity
+                            supportsDistanceMetrics = activity.supportsDistanceMetrics
                         }
                     },
                     onDistanceChange = { newDistance ->
@@ -237,6 +239,8 @@ fun TaskCreateForm(
             }
 
             if (targetClass != SportTask::class) {
+                supportsDistanceMetrics = false
+
                 EditableInfoItem(
                     dialogContent = {
                         Column {
@@ -355,6 +359,14 @@ fun TaskCreateForm(
                         if (reminderTime?.toMinutes()?.toInt() == 1) "minute" else "minutes"
                     } before task" else ""
             )
+
+            if (supportsDistanceMetrics) {
+                Text(
+                    text = "${activity.title} is likely to be autocompleted",
+                    style = TextStyle(fontSize = 14.sp),
+                    modifier = Modifier.padding(vertical = 4.dp)
+                )
+            }
 
             Button(
                 onClick = {

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
@@ -143,7 +143,6 @@ fun TaskCreateForm(
     var duration by remember { mutableStateOf(Duration.ofMinutes(0)) }
     var reminderTime by remember { mutableStateOf<Duration?>(null) }
     var activity by remember { mutableStateOf(SportActivity.Walking) }
-    //var supportsDistanceMetrics by remember { mutableStateOf(false) }
     var distance by remember { mutableDoubleStateOf(0.0) }
     var dateTime by remember { mutableStateOf(date ?: LocalDateTime.now()) }
     var editingTitle by remember { mutableStateOf("") }
@@ -239,8 +238,6 @@ fun TaskCreateForm(
             }
 
             if (targetClass != SportTask::class) {
-                //supportsDistanceMetrics = false
-
                 EditableInfoItem(
                     dialogContent = {
                         Column {

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
@@ -360,14 +360,6 @@ fun TaskCreateForm(
                     } before task" else ""
             )
 
-            if (supportsDistanceMetrics) {
-                Text(
-                    text = "${activity.title} is likely to be autocompleted",
-                    style = TextStyle(fontSize = 14.sp),
-                    modifier = Modifier.padding(vertical = 4.dp)
-                )
-            }
-
             Button(
                 onClick = {
                     when (targetClass) {

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
@@ -143,7 +143,7 @@ fun TaskCreateForm(
     var duration by remember { mutableStateOf(Duration.ofMinutes(0)) }
     var reminderTime by remember { mutableStateOf<Duration?>(null) }
     var activity by remember { mutableStateOf(SportActivity.Walking) }
-    var supportsDistanceMetrics by remember { mutableStateOf(false) }
+    //var supportsDistanceMetrics by remember { mutableStateOf(false) }
     var distance by remember { mutableDoubleStateOf(0.0) }
     var dateTime by remember { mutableStateOf(date ?: LocalDateTime.now()) }
     var editingTitle by remember { mutableStateOf("") }
@@ -224,7 +224,7 @@ fun TaskCreateForm(
                     onActivityChange = { newActivity ->
                         if (newActivity != null) {
                             activity = newActivity
-                            supportsDistanceMetrics = activity.supportsDistanceMetrics
+                            //supportsDistanceMetrics = activity.supportsDistanceMetrics
                         }
                     },
                     onDistanceChange = { newDistance ->
@@ -239,7 +239,7 @@ fun TaskCreateForm(
             }
 
             if (targetClass != SportTask::class) {
-                supportsDistanceMetrics = false
+                //supportsDistanceMetrics = false
 
                 EditableInfoItem(
                     dialogContent = {


### PR DESCRIPTION
after selecting an activity in the task form a note appears above the create button indicating that the task will likely be autocompleted if the activity supports distance metrics:

![image](https://github.com/PVP-K410/Calendar/assets/92679973/9d872e02-c237-495a-b5d6-a5b274268ed1)

the note disappears after changing to a non-distance activity or to a different type of task (general or meal).