### PR TITLE
PVP-235

### DIFF
--- a/app/src/main/java/com/pvp/app/api/GoalService.kt
+++ b/app/src/main/java/com/pvp/app/api/GoalService.kt
@@ -1,0 +1,47 @@
+package com.pvp.app.api
+
+import com.pvp.app.model.Goal
+import com.pvp.app.model.SportActivity
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+
+interface GoalService: DocumentsCollection {
+
+    override val identifier: String
+        get() = "goals"
+
+    /**
+     * Creates a new goal in the database.
+     */
+    suspend fun create(
+        activity: SportActivity,
+        endDate: LocalDate,
+        email: String,
+        goal: Double,
+        monthly: Boolean,
+        startDate: LocalDate,
+        steps: Boolean
+    )
+
+    suspend fun claim(
+        goal: Goal
+    )
+
+    /**
+     * Gets all goals for the specified email.
+     */
+    suspend fun get(email: String): Flow<List<Goal>>
+
+    /**
+     * Gets all goals for the specified email and start date.
+     */
+    suspend fun get(
+        email: String,
+        startDate: LocalDate
+    ): Flow<List<Goal>>
+
+    /**
+     * Updates the goal in the database.
+     */
+    suspend fun update(goal: Goal)
+}

--- a/app/src/main/java/com/pvp/app/api/PointService.kt
+++ b/app/src/main/java/com/pvp/app/api/PointService.kt
@@ -1,5 +1,6 @@
 package com.pvp.app.api
 
+import com.pvp.app.model.Goal
 import com.pvp.app.model.Task
 import java.time.LocalDate
 
@@ -31,6 +32,16 @@ interface PointService {
     ): Int {
         return tasks.sumOf { calculate(it) }
     }
+
+    /**
+     * Calculate the points of a goal. Points are determined by the goal type and the attributes of
+     * the goal. User status can also be taken into account, hence, [Goal.email] is required.
+     *
+     * @param goal goal to calculate points for
+     *
+     * @return points of the goal
+     */
+    suspend fun calculate(goal: Goal): Int
 
     /**
      * Deduct points from current user for not completing tasks.

--- a/app/src/main/java/com/pvp/app/di/ServiceModule.kt
+++ b/app/src/main/java/com/pvp/app/di/ServiceModule.kt
@@ -14,6 +14,7 @@ import com.pvp.app.api.DecorationService
 import com.pvp.app.api.ExerciseService
 import com.pvp.app.api.ExperienceService
 import com.pvp.app.api.FriendService
+import com.pvp.app.api.GoalService
 import com.pvp.app.api.HealthConnectService
 import com.pvp.app.api.ImageService
 import com.pvp.app.api.NotificationService
@@ -30,6 +31,7 @@ import com.pvp.app.service.DecorationServiceImpl
 import com.pvp.app.service.ExerciseServiceImpl
 import com.pvp.app.service.ExperienceServiceImpl
 import com.pvp.app.service.FriendServiceImpl
+import com.pvp.app.service.GoalServiceImpl
 import com.pvp.app.service.HealthConnectServiceImpl
 import com.pvp.app.service.ImageServiceImpl
 import com.pvp.app.service.NotificationServiceImpl
@@ -78,6 +80,10 @@ interface ServiceBindingsModule {
     @Binds
     @Singleton
     fun bindFriendService(service: FriendServiceImpl): FriendService
+
+    @Binds
+    @Singleton
+    fun bindGoalService(service: GoalServiceImpl): GoalService
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/pvp/app/model/Goal.kt
+++ b/app/src/main/java/com/pvp/app/model/Goal.kt
@@ -1,0 +1,22 @@
+package com.pvp.app.model
+
+import com.pvp.app.common.LocalDateSerializer
+import kotlinx.serialization.Serializable
+import java.time.LocalDate
+
+@Serializable
+data class Goal(
+    val activity: SportActivity = SportActivity.Other,
+    var completed: Boolean = false,
+    @Serializable(LocalDateSerializer::class)
+    val endDate: LocalDate,
+    val email: String = "",
+    val goal: Double = 0.0,
+    val id: String = "",
+    val monthly: Boolean = false,
+    var points: Points,
+    var progress: Double = 0.0,
+    @Serializable(LocalDateSerializer::class)
+    val startDate: LocalDate,
+    val steps: Boolean = false
+)

--- a/app/src/main/java/com/pvp/app/service/GoalServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/GoalServiceImpl.kt
@@ -1,0 +1,165 @@
+package com.pvp.app.service
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.snapshots
+import com.pvp.app.api.ExperienceService
+import com.pvp.app.api.GoalService
+import com.pvp.app.api.PointService
+import com.pvp.app.api.UserService
+import com.pvp.app.common.JsonUtil.JSON
+import com.pvp.app.common.JsonUtil.toJsonElement
+import com.pvp.app.common.JsonUtil.toPrimitivesMap
+import com.pvp.app.model.Goal
+import com.pvp.app.model.Points
+import com.pvp.app.model.SportActivity
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.tasks.await
+import kotlinx.serialization.json.decodeFromJsonElement
+import kotlinx.serialization.json.encodeToJsonElement
+import java.time.LocalDate
+import java.time.LocalDateTime
+import javax.inject.Inject
+
+class GoalServiceImpl @Inject constructor(
+    private val database: FirebaseFirestore,
+    private val experienceService: ExperienceService,
+    private val pointService: PointService,
+    private val userService: UserService
+) : GoalService {
+    override suspend fun create(
+        activity: SportActivity,
+        endDate: LocalDate,
+        email: String,
+        goal: Double,
+        monthly: Boolean,
+        startDate: LocalDate,
+        steps: Boolean
+    ) {
+        val reference = database
+            .collection(identifier)
+            .document()
+
+        val goalEntry = Goal(
+            activity = activity,
+            completed = false,
+            endDate = endDate,
+            email = email,
+            goal = goal,
+            monthly = monthly,
+            id = reference.id,
+            points = Points(),
+            progress = 0.0,
+            startDate = startDate,
+            steps = steps
+        )
+
+        goalEntry.points = goalEntry.points.copy(
+            isExpired = goalEntry.endDate.isBefore(LocalDate.now()),
+            value = pointService.calculate(goalEntry)
+        )
+
+        database
+            .runTransaction {
+                it.set(
+                    reference,
+                    JSON
+                        .encodeToJsonElement<Goal>(goalEntry)
+                        .toPrimitivesMap()
+                )
+            }
+            .await()
+    }
+
+    override suspend fun claim(
+        goal: Goal
+    ) {
+        if (goal.points.claimedAt != null) {
+            error("Goal points are already claimed")
+        }
+
+        goal.points = goal.points.copy(claimedAt = LocalDateTime.now())
+        goal.completed = true
+
+        userService
+            .get(goal.email)
+            .firstOrNull()
+            ?.let { user ->
+                val points = goal.points.value
+                val experience = user.experience + points
+
+                userService.merge(
+                    user.copy(
+                        experience = experience,
+                        level = experienceService.levelOf(experience),
+                        points = user.points + points
+                    )
+                )
+            } ?: error("User not found while claiming goal")
+
+        update(goal)
+    }
+
+    override suspend fun get(email: String): Flow<List<Goal>> {
+        return database
+            .collection(identifier)
+            .whereEqualTo(
+                Goal::email.name,
+                email
+            )
+            .snapshots()
+            .map { qs ->
+                qs.documents
+                    .filter { it.exists() }
+                    .mapNotNull {
+                        JSON.decodeFromJsonElement<Goal>(
+                            it.data.toJsonElement()
+                        )
+                    }
+            }
+    }
+
+    override suspend fun get(
+        email: String,
+        startDate: LocalDate
+    ): Flow<List<Goal>> {
+        return database
+            .collection(identifier)
+            .whereEqualTo(
+                Goal::email.name,
+                email
+            )
+            .whereEqualTo(
+                Goal::startDate.name,
+                startDate.toString()
+            )
+            .snapshots()
+            .map { qs ->
+                qs.documents
+                    .filter { it.exists() }
+                    .mapNotNull {
+                        JSON.decodeFromJsonElement<Goal>(
+                            it.data.toJsonElement()
+                        )
+                    }
+            }
+    }
+
+    override suspend fun update(goal: Goal) {
+        val reference = database
+            .collection(identifier)
+            .document(goal.id)
+
+        database
+            .runTransaction {
+                it.set(
+                    reference,
+                    JSON
+                        .encodeToJsonElement<Goal>(goal)
+                        .toPrimitivesMap()
+                )
+            }
+            .await()
+    }
+}

--- a/app/src/main/java/com/pvp/app/service/GoalServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/GoalServiceImpl.kt
@@ -28,6 +28,7 @@ class GoalServiceImpl @Inject constructor(
     private val pointService: PointService,
     private val userService: UserService
 ) : GoalService {
+
     override suspend fun create(
         activity: SportActivity,
         endDate: LocalDate,

--- a/app/src/main/java/com/pvp/app/service/PointServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/PointServiceImpl.kt
@@ -6,6 +6,7 @@ import com.pvp.app.api.Configuration
 import com.pvp.app.api.PointService
 import com.pvp.app.api.TaskService
 import com.pvp.app.api.UserService
+import com.pvp.app.model.Goal
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
@@ -90,6 +91,24 @@ class PointServiceImpl @Inject constructor(
 
                 it
             }
+    }
+
+    override suspend fun calculate(goal: Goal): Int {
+        return when (goal.monthly) {
+            false -> {
+                calculateDistancePoints(
+                    distance = goal.goal / 7.0,
+                    ratio = goal.activity.pointsRatioDistance
+                ) * 7
+            }
+
+            true -> {
+                calculateDistancePoints(
+                    distance = goal.goal / 30.0,
+                    ratio = goal.activity.pointsRatioDistance
+                ) * 30
+            }
+        }
     }
 
     private fun calculateDistancePoints(

--- a/app/src/main/java/com/pvp/app/ui/router/Routes.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Routes.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.DirectionsWalk
 import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.EmojiEvents
 import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Storefront
@@ -16,6 +17,7 @@ import com.pvp.app.ui.screen.authentication.AuthenticationScreen
 import com.pvp.app.ui.screen.calendar.CalendarScreen
 import com.pvp.app.ui.screen.decoration.DecorationScreen
 import com.pvp.app.ui.screen.friends.FriendsScreen
+import com.pvp.app.ui.screen.goals.GoalScreen
 import com.pvp.app.ui.screen.settings.SettingsScreen
 import com.pvp.app.ui.screen.steps.StepScreen
 import com.pvp.app.ui.screen.survey.SurveyScreen
@@ -41,6 +43,7 @@ sealed class Route(
             Calendar,
             Decorations,
             Friends,
+            Goals,
             None,
             Settings,
             Steps
@@ -58,6 +61,7 @@ sealed class Route(
             Calendar,
             Decorations,
             Friends,
+            Goals,
             Settings,
             Steps
         )
@@ -103,6 +107,14 @@ sealed class Route(
         path = "friends",
         resourceTitleId = R.string.route_friends,
         screen = { _, m, _ -> FriendsScreen(modifier = m) }
+    )
+
+    data object Goals : Route(
+        icon = Icons.Outlined.EmojiEvents,
+        iconDescription = "Goals page button icon",
+        path = "goals",
+        resourceTitleId = R.string.route_goals,
+        screen = { _, m, _ -> GoalScreen(modifier = m) }
     )
 
     data object None : Route(

--- a/app/src/main/java/com/pvp/app/ui/screen/goals/GoalCreation.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/goals/GoalCreation.kt
@@ -1,0 +1,383 @@
+package com.pvp.app.ui.screen.goals
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableDoubleStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pvp.app.model.SportActivity
+import com.pvp.app.ui.common.Button
+import com.pvp.app.ui.common.EditableInfoItem
+import com.pvp.app.ui.common.LabelFieldWrapper
+import com.pvp.app.ui.common.Picker
+import com.pvp.app.ui.common.PickerPair
+import com.pvp.app.ui.common.PickerState
+import java.time.LocalDate
+
+private val goalActivities: List<SportActivity> = listOf(
+    SportActivity.Cycling,
+    SportActivity.Hiking,
+    SportActivity.Rowing,
+    SportActivity.Running,
+    SportActivity.Skiing,
+    SportActivity.Snowboarding,
+    SportActivity.Swimming,
+    SportActivity.Walking
+)
+
+@Composable
+fun DistancePicker(
+    model: GoalViewModel = hiltViewModel(),
+    distance: Double,
+    onDistanceChange: (Double) -> Unit
+) {
+    val stateKilometers = PickerState.rememberPickerState(
+        distance.toInt()
+    )
+
+    val stateMeters = PickerState.rememberPickerState(
+        distance.let { ((it - stateKilometers.value) * 900).toInt() }
+    )
+
+    EditableInfoItem(
+        dialogContent = {
+            LabelFieldWrapper(
+                content = {
+                    PickerPair(
+                        itemsFirst = model.rangeKilometers,
+                        itemsSecond = (0..1000 step 100).toList(),
+                        labelFirst = { "$it (km)" },
+                        labelSecond = { "$it (m)" },
+                        onChange = { stateFirst, stateSecond ->
+                            stateKilometers.value = stateFirst
+                            stateMeters.value = stateSecond
+                        },
+                        stateFirst = stateKilometers,
+                        stateSecond = stateMeters
+                    )
+                },
+                putBelow = true,
+                text = "${stateKilometers.value + (stateMeters.value / 1000.0)} (km) distance",
+                textAlign = TextAlign.End
+            )
+        },
+        dialogTitle = { Text("Editing distance") },
+        label = "Distance",
+        onConfirm = { onDistanceChange(stateKilometers.value + (stateMeters.value / 1000.0)) },
+        onDismiss = { },
+        value = "${stateKilometers.value + (stateMeters.value / 1000.0)} (km)"
+    )
+}
+
+@Composable
+fun GoalCreateDialog(
+    onClose: () -> Unit,
+    isOpen: Boolean,
+) {
+    if (!isOpen) {
+        return
+    }
+
+    Dialog(onDismissRequest = onClose) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(MaterialTheme.colorScheme.surfaceContainer)
+                .padding(8.dp)
+        ) {
+            GoalCreateForm(onCreate = onClose)
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun GoalCreateForm(
+    model: GoalViewModel = hiltViewModel(),
+    onCreate: () -> Unit
+) {
+    var activity by remember { mutableStateOf(SportActivity.Walking) }
+    var tempActivity by remember { mutableStateOf(activity) }
+    var goal by remember { mutableDoubleStateOf(0.0) }
+    val state by model.state.collectAsStateWithLifecycle()
+    var steps by remember { mutableStateOf(activity == SportActivity.Walking) }
+    var stepCount by remember { mutableDoubleStateOf(0.0) }
+    var monthly by remember { mutableStateOf(state.monthly) }
+
+    val isFormValid by remember(goal) {
+        derivedStateOf {
+            goal > 0 || (stepCount > 0 && steps)
+        }
+    }
+
+    Surface(
+        shape = RoundedCornerShape(10.dp),
+        color = MaterialTheme.colorScheme.surfaceContainer
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp)
+        ) {
+            var value by remember {
+                mutableStateOf(
+                    if (monthly) {
+                        GoalFilter.Monthly
+                    } else {
+                        GoalFilter.Weekly
+                    }
+                )
+            }
+
+            GoalTypeFilter(filter = value) {
+                monthly = it == GoalFilter.Monthly
+                value = it
+            }
+
+            Spacer(modifier = Modifier.padding(top = 4.dp))
+
+            val now = LocalDate.now()
+
+            val (start, end) = when (monthly) {
+                true -> {
+                    Pair(
+                        now,
+                        now.plusMonths(1)
+                    )
+                }
+
+                false -> {
+                    Pair(
+                        now,
+                        now.plusDays(7)
+                    )
+                }
+            }
+
+            Text(
+                style = MaterialTheme.typography.labelSmall,
+                fontSize = 10.sp,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                text = "$start - $end"
+            )
+
+            Spacer(modifier = Modifier.padding(top = 8.dp))
+
+            EditableInfoItem(
+                dialogContent = {
+                    var isExpanded by remember { mutableStateOf(false) }
+
+                    ExposedDropdownMenuBox(
+                        expanded = isExpanded,
+                        onExpandedChange = { isExpanded = it },
+                    ) {
+                        TextField(
+                            modifier = Modifier
+                                .menuAnchor()
+                                .fillMaxWidth()
+                                .padding(bottom = 16.dp),
+                            value = tempActivity.title,
+                            onValueChange = {},
+                            readOnly = true,
+                            trailingIcon = {
+                                ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpanded)
+                            }
+                        )
+
+                        ExposedDropdownMenu(
+                            expanded = isExpanded,
+                            onDismissRequest = { isExpanded = false }
+                        ) {
+                            goalActivities.forEach {
+                                DropdownMenuItem(
+                                    text = { Text(text = it.title) },
+                                    onClick = {
+                                        tempActivity = it
+                                        isExpanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                },
+                dialogTitle = { Text("Editing activity") },
+                label = "Activity",
+                onConfirm = {
+                    activity = tempActivity
+                    steps = activity == SportActivity.Walking && goal == 0.0
+                },
+                onDismiss = { tempActivity = activity },
+                value = activity?.title ?: ""
+            )
+
+            Spacer(modifier = Modifier.padding(top = 8.dp))
+
+            if (activity == SportActivity.Walking) {
+                StepSelector(
+                    isSelected = steps
+                ) {
+                    steps = !steps
+                }
+
+                Spacer(modifier = Modifier.padding(top = 8.dp))
+            }
+
+            when (steps) {
+                true -> {
+                    StepPicker(steps = stepCount) {
+                        stepCount = it
+                        goal = 0.0
+                    }
+                }
+
+                false -> {
+                    DistancePicker(distance = goal) {
+                        goal = it
+                        stepCount = 0.0
+                        steps = false
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.padding(top = 8.dp))
+
+            Button(
+                onClick = {
+                    model.create(
+                        activity = activity,
+                        goal = if (steps) stepCount else goal,
+                        monthly = monthly,
+                        steps = steps,
+                    )
+
+                    onCreate()
+                },
+                enabled = isFormValid,
+                modifier = Modifier.align(Alignment.CenterHorizontally)
+            ) {
+                Text("Create")
+            }
+        }
+    }
+}
+
+@Composable
+fun StepPicker(
+    steps: Double,
+    onStepChange: (Double) -> Unit
+) {
+    var stepCount by remember { mutableDoubleStateOf(steps) }
+
+    EditableInfoItem(
+        dialogContent = {
+            LabelFieldWrapper(
+                content = {
+                    Picker(
+                        items = (14000..140000 step 1000).toList(),
+                        label = { "$it" },
+                        onChange = { state ->
+                            stepCount = state.toDouble()
+                        },
+                        state = PickerState.rememberPickerState(
+                            steps.toInt()
+                        )
+                    )
+                },
+                putBelow = true,
+                text = "${steps.toInt()} steps",
+                textAlign = TextAlign.End
+            )
+        },
+        dialogTitle = { Text("Editing steps") },
+        label = "Steps",
+        onConfirm = { onStepChange(stepCount) },
+        onDismiss = { },
+        value = "${steps.toInt()} steps"
+    )
+}
+
+@Composable
+private fun StepSelector(
+    isSelected: Boolean,
+    onClick: () -> Unit
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .background(
+                MaterialTheme.colorScheme.surfaceContainer,
+                MaterialTheme.shapes.medium
+            )
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .height(40.dp)
+                .clickable { onClick() }
+                .background(
+                    if (isSelected) {
+                        MaterialTheme.colorScheme.secondaryContainer
+                    } else {
+                        Color.Transparent
+                    },
+                    MaterialTheme.shapes.medium
+                )
+        ) {
+            Text(text = "Steps")
+        }
+
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .height(40.dp)
+                .clickable { onClick() }
+                .background(
+                    if (!isSelected) {
+                        MaterialTheme.colorScheme.secondaryContainer
+                    } else {
+                        Color.Transparent
+                    },
+                    MaterialTheme.shapes.medium
+                )
+        ) {
+            Text(text = "Distance")
+        }
+    }
+}

--- a/app/src/main/java/com/pvp/app/ui/screen/goals/GoalCreation.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/goals/GoalCreation.kt
@@ -241,7 +241,7 @@ fun GoalCreateForm(
                 value = activity.title ?: ""
             )
 
-            Spacer(modifier = Modifier.padding(top = 8.dp))
+            Spacer(modifier = Modifier.padding(4.dp))
 
             if (activity == SportActivity.Walking) {
                 StepSelector(
@@ -250,7 +250,7 @@ fun GoalCreateForm(
                     steps = !steps
                 }
 
-                Spacer(modifier = Modifier.padding(top = 8.dp))
+                Spacer(modifier = Modifier.padding(4.dp))
             }
 
             when (steps) {
@@ -270,7 +270,7 @@ fun GoalCreateForm(
                 }
             }
 
-            Spacer(modifier = Modifier.padding(top = 8.dp))
+            Spacer(modifier = Modifier.padding(4.dp))
 
             Button(
                 onClick = {

--- a/app/src/main/java/com/pvp/app/ui/screen/goals/GoalCreation.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/goals/GoalCreation.kt
@@ -238,7 +238,7 @@ fun GoalCreateForm(
                     steps = activity == SportActivity.Walking && goal == 0.0
                 },
                 onDismiss = { tempActivity = activity },
-                value = activity?.title ?: ""
+                value = activity.title ?: ""
             )
 
             Spacer(modifier = Modifier.padding(top = 8.dp))

--- a/app/src/main/java/com/pvp/app/ui/screen/goals/GoalScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/goals/GoalScreen.kt
@@ -170,9 +170,7 @@ fun GoalCard(
             ) {
                 Text(
                     style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.padding(
-                        end = 8.dp
-                    ),
+                    modifier = Modifier.padding(end = 8.dp),
                     textAlign = TextAlign.Left,
                     text = "Set goal: ${
                         when (goal.steps) {
@@ -189,7 +187,7 @@ fun GoalCard(
             }
 
             if (goal.steps) {
-                Spacer(modifier = Modifier.padding(4.dp))
+                Spacer(modifier = Modifier.padding(2.dp))
 
                 Text(
                     style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/pvp/app/ui/screen/goals/GoalScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/goals/GoalScreen.kt
@@ -1,0 +1,260 @@
+package com.pvp.app.ui.screen.goals
+
+import android.annotation.SuppressLint
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.FabPosition
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pvp.app.model.Goal
+import com.pvp.app.ui.screen.layout.FloatingActionButton
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun GoalScreen(
+    model: GoalViewModel = hiltViewModel(),
+    modifier: Modifier
+) {
+    val state by model.state.collectAsStateWithLifecycle()
+    var isGoalDialogOpen by remember { mutableStateOf(false) }
+    val toggleGoalDialog = remember { { isGoalDialogOpen = !isGoalDialogOpen } }
+
+    Scaffold(
+        content = {
+            Box(
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(16.dp)
+            ) {
+                Column {
+                    val goals = state.currentGoals
+                    var filter by remember { mutableStateOf(GoalFilter.Weekly) }
+
+                    GoalTypeFilter(filter = filter) {
+                        if (it != filter) model.changeMonthly()
+                        filter = it
+                    }
+
+                    LazyColumn(modifier = Modifier.fillMaxWidth()) {
+                        if (!goals.any()) {
+                            item {
+                                Box(
+                                    contentAlignment = Alignment.Center,
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    Text(
+                                        fontStyle = FontStyle.Italic,
+                                        modifier = Modifier.padding(32.dp),
+                                        style = MaterialTheme.typography.bodyMedium,
+                                        text = "No goals have been set up yet."
+                                    )
+                                }
+                            }
+                        } else {
+                            items(goals) { goal ->
+                                GoalCard(goal = goal)
+                            }
+                        }
+                    }
+                }
+            }
+
+            GoalCreateDialog(
+                onClose = toggleGoalDialog,
+                isOpen = isGoalDialogOpen,
+            )
+        },
+        floatingActionButton = {
+            FloatingActionButton(toggleGoalDialog)
+        },
+        floatingActionButtonPosition = FabPosition.End,
+    )
+}
+
+@Composable
+fun GoalCard(goal: Goal) {
+    Box(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(4.dp)
+            .clip(RoundedCornerShape(10.dp))
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(8.dp)
+                .fillMaxWidth()
+        ) {
+            Text(
+                style = MaterialTheme.typography.titleMedium,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                text = goal.activity.title + if (goal.monthly) {
+                    " monthly"
+                } else {
+                    " weekly"
+                } + " goal"
+            )
+
+            Spacer(modifier = Modifier.padding(top = 4.dp))
+
+            Text(
+                style = MaterialTheme.typography.labelSmall,
+                fontSize = 10.sp,
+                modifier = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                text = goal.startDate.toString() + " - " + goal.endDate.toString()
+            )
+
+            Spacer(modifier = Modifier.padding(top = 8.dp))
+
+            ProgressBar(goal = goal)
+
+            Spacer(modifier = Modifier.padding(top = 8.dp))
+
+            Row(
+                modifier = Modifier.padding(6.dp)
+            ) {
+                Icon(
+                    imageVector = goal.activity.icon,
+                    contentDescription = "Activity icon",
+                )
+
+                Text(
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(8.dp),
+                    textAlign = TextAlign.Justify,
+                    text = "Set goal: ${
+                        if (goal.steps) {
+                            "${goal.goal.toInt()} steps"
+                        } else {
+                            "${goal.goal} km"
+                        }
+                    }"
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun GoalTypeFilter(
+    filter: GoalFilter,
+    onClick: (GoalFilter) -> Unit
+) {
+    Row(
+        horizontalArrangement = Arrangement.SpaceBetween,
+        modifier = Modifier
+            .background(
+                MaterialTheme.colorScheme.surfaceContainer,
+                MaterialTheme.shapes.medium
+            )
+            .fillMaxWidth()
+            .padding(vertical = 4.dp)
+    ) {
+        GoalFilter.entries.forEach { filterNew ->
+            GoalTypeSelector(
+                filter = filterNew,
+                isSelected = filter == filterNew,
+                onClick = { onClick(filterNew) },
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+                    .height(40.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun GoalTypeSelector(
+    filter: GoalFilter,
+    isSelected: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = modifier
+            .clickable { onClick() }
+            .background(
+                if (isSelected) {
+                    MaterialTheme.colorScheme.secondaryContainer
+                } else {
+                    Color.Transparent
+                },
+                MaterialTheme.shapes.medium
+            )
+    ) {
+        Text(text = filter.displayName)
+    }
+}
+
+@Composable
+fun ProgressBar(goal: Goal) {
+    val progress by animateFloatAsState(
+        animationSpec = tween(durationMillis = 1000),
+        label = "ExperienceProgressAnimation",
+        targetValue = goal.progress.toFloat(),
+    )
+
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(32.dp)
+    ) {
+        LinearProgressIndicator(
+            color = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.7f),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(32.dp),
+            progress = { progress },
+            strokeCap = StrokeCap.Round,
+            trackColor = MaterialTheme.colorScheme.tertiary.copy(alpha = 0.4f)
+        )
+
+        Text(
+            text = "${goal.progress} / ${goal.goal}" + if (goal.steps) " steps" else " km",
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+enum class GoalFilter(val displayName: String) {
+    Weekly("Weekly"),
+    Monthly("Monthly")
+}

--- a/app/src/main/java/com/pvp/app/ui/screen/goals/GoalScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/goals/GoalScreen.kt
@@ -99,7 +99,10 @@ fun GoalScreen(
                             }
                         } else {
                             items(goals) { goal ->
-                                GoalCard(goal = goal)
+                                GoalCard(
+                                    goal = goal,
+                                    monthSteps = state.monthSteps
+                                )
                             }
                         }
                     }
@@ -119,7 +122,10 @@ fun GoalScreen(
 }
 
 @Composable
-fun GoalCard(goal: Goal) {
+fun GoalCard(
+    goal: Goal,
+    monthSteps: Long
+) {
     Box(
         modifier = Modifier
             .fillMaxWidth()
@@ -143,7 +149,7 @@ fun GoalCard(goal: Goal) {
                 } + " goal"
             )
 
-            Spacer(modifier = Modifier.padding(top = 4.dp))
+            Spacer(modifier = Modifier.padding(2.dp))
 
             Text(
                 style = MaterialTheme.typography.labelSmall,
@@ -153,25 +159,20 @@ fun GoalCard(goal: Goal) {
                 text = goal.startDate.toString() + " - " + goal.endDate.toString()
             )
 
-            Spacer(modifier = Modifier.padding(top = 8.dp))
+            Spacer(modifier = Modifier.padding(8.dp))
 
             ProgressBar(goal = goal)
 
-            Spacer(modifier = Modifier.padding(top = 8.dp))
+            Spacer(modifier = Modifier.padding(4.dp))
 
             Row(
                 modifier = Modifier.padding(6.dp)
             ) {
-                Icon(
-                    imageVector = goal.activity.icon,
-                    contentDescription = "Activity icon",
-                )
-
                 Text(
-                    style = MaterialTheme.typography.titleMedium,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 8.dp),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(
+                        end = 8.dp
+                    ),
                     textAlign = TextAlign.Left,
                     text = "Set goal: ${
                         when (goal.steps) {
@@ -179,6 +180,25 @@ fun GoalCard(goal: Goal) {
                             false -> "${goal.goal} km"
                         }
                     }"
+                )
+
+                Icon(
+                    imageVector = goal.activity.icon,
+                    contentDescription = "Activity icon",
+                )
+            }
+
+            if (goal.steps) {
+                Spacer(modifier = Modifier.padding(4.dp))
+
+                Text(
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(start = 6.dp),
+                    textAlign = TextAlign.Left,
+                    text = "Your average " + when (goal.monthly) {
+                        true -> "monthly steps: $monthSteps"
+                        false -> "weekly steps: ${monthSteps / 30 * 7}"
+                    }
                 )
             }
         }
@@ -221,8 +241,7 @@ private fun GoalTypeSelector(
     onClick: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Box(
-        contentAlignment = Alignment.Center,
+    Box(contentAlignment = Alignment.Center,
         modifier = modifier
             .clickable { onClick() }
             .background(
@@ -232,8 +251,7 @@ private fun GoalTypeSelector(
                     Color.Transparent
                 },
                 MaterialTheme.shapes.medium
-            )
-    ) {
+            )) {
         Text(text = filter.displayName)
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/goals/GoalViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/goals/GoalViewModel.kt
@@ -1,6 +1,5 @@
 package com.pvp.app.ui.screen.goals
 
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pvp.app.api.Configuration
@@ -164,7 +163,7 @@ class GoalViewModel @Inject constructor(
         }
     }
 
-    suspend fun getMonthSteps(): Long{
+    private suspend fun getMonthSteps(): Long {
         val end = Instant.now()
 
         val start = LocalDate

--- a/app/src/main/java/com/pvp/app/ui/screen/goals/GoalViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/goals/GoalViewModel.kt
@@ -1,0 +1,202 @@
+package com.pvp.app.ui.screen.goals
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pvp.app.api.Configuration
+import com.pvp.app.api.GoalService
+import com.pvp.app.api.UserService
+import com.pvp.app.model.Goal
+import com.pvp.app.model.SportActivity
+import com.pvp.app.model.User
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+import javax.inject.Inject
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@HiltViewModel
+class GoalViewModel @Inject constructor(
+    configuration: Configuration,
+    private val goalService: GoalService,
+    private val userService: UserService
+) : ViewModel(
+) {
+
+    private val _state = MutableStateFlow(GoalState())
+    val state = _state.asStateFlow()
+
+    val rangeKilometers = configuration.rangeKilometers
+
+    init {
+        viewModelScope.launch {
+            val flowUser = userService.user
+
+            val flowGoals = flowUser.flatMapLatest { user ->
+                user
+                    ?.let { goalService.get(user.email) }
+                    ?: flowOf(listOf())
+            }
+
+            flowUser
+                .combine(flowGoals) { user, goals ->
+                    user ?: return@combine _state.value
+                    val now = LocalDate.now()
+                    val weekStartDate = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+                    val weekEndDate = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SUNDAY))
+                    GoalState(
+                        allGoals = goals,
+                        currentGoals = filterGoals(
+                            goals = goals,
+                            start = weekStartDate,
+                            end = weekEndDate,
+                            monthly = false
+                        ),
+                        user = user,
+                        monthStartDate = now.withDayOfMonth(1),
+                        monthEndDate = now
+                            .plusMonths(1)
+                            .withDayOfMonth(1),
+                        monthly = false,
+                        weekStartDate = weekStartDate,
+                        weekEndDate = weekEndDate
+                    )
+                }
+                .collect { state -> _state.update { state } }
+        }
+    }
+
+    fun create(
+        activity: SportActivity,
+        goal: Double,
+        monthly: Boolean,
+        steps: Boolean
+    ) {
+        val startDate = LocalDate.now()
+
+        val endDate = if (monthly) {
+            startDate.plusMonths(1)
+        } else {
+            startDate.plusDays(7)
+        }
+        viewModelScope.launch {
+            state
+                .first()
+                .let { state ->
+                    goalService.create(
+                        activity = activity,
+                        goal = goal,
+                        startDate = startDate,
+                        endDate = endDate,
+                        monthly = monthly,
+                        steps = steps,
+                        email = state.user!!.email
+                    )
+                }
+        }
+    }
+
+    fun changeMonthly() {
+        _state.update { currentState ->
+            currentState.copy(
+                monthly = !currentState.monthly
+            )
+        }
+
+        Log.e("GoalViewModel", "changeMonthly value ${state.value.monthly}")
+
+        filterGoals()
+    }
+
+    private fun filterGoals(
+        goals: List<Goal>,
+        start: LocalDate,
+        end: LocalDate,
+        monthly: Boolean
+    ): List<Goal> {
+        Log.e("GoalViewModel", "filterGoals value start: $start end $end monthly $monthly")
+
+        return goals.filter { goal ->
+            goal.startDate.isBefore(end.plusDays(1)) && goal.endDate.isAfter(start.minusDays(1))
+                    && goal.monthly == monthly
+        }
+    }
+
+    private fun filterGoals() {
+        val (start, end) = when (state.value.monthly) {
+            true -> {
+                Pair(
+                    state.value.monthStartDate,
+                    state.value.monthEndDate
+                )
+            }
+
+            false -> {
+                Pair(
+                    state.value.weekStartDate,
+                    state.value.weekEndDate
+                )
+            }
+        }
+        Log.e("GoalViewModel", "filterGoals value start: $start end $end")
+
+
+        _state.update { currentState ->
+            currentState.copy(
+                currentGoals = filterGoals(
+                    goals = currentState.allGoals,
+                    start = start,
+                    end = end,
+                    monthly = currentState.monthly
+                )
+            )
+        }
+    }
+
+    fun next() {
+        _state.update { currentState ->
+            currentState.copy(
+                monthStartDate = currentState.monthStartDate.plusMonths(1),
+                monthEndDate = currentState.monthEndDate.plusMonths(1),
+                weekStartDate = currentState.weekStartDate.minusDays(7),
+                weekEndDate = currentState.weekEndDate.minusDays(7)
+            )
+        }
+
+        filterGoals()
+    }
+
+    fun previous() {
+        _state.update { currentState ->
+            currentState.copy(
+                monthStartDate = currentState.monthStartDate.minusMonths(1),
+                monthEndDate = currentState.monthEndDate.minusMonths(1),
+                weekStartDate = currentState.weekStartDate.minusDays(7),
+                weekEndDate = currentState.weekEndDate.minusDays(7)
+            )
+        }
+
+        filterGoals()
+    }
+}
+
+data class GoalState(
+    val allGoals: List<Goal> = listOf(),
+    val currentGoals: List<Goal> = listOf(),
+    var monthly: Boolean = false,
+    var monthStartDate: LocalDate = LocalDate.now(),
+    var monthEndDate: LocalDate = LocalDate.now(),
+    val user: User? = null,
+    var weekStartDate: LocalDate = LocalDate.now(),
+    var weekEndDate: LocalDate = LocalDate.now()
+)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="route_calendar">Calendar</string>
     <string name="route_decorations">Decorations</string>
     <string name="route_friends">Friends</string>
+    <string name="route_goals">Goals</string>
     <string name="route_profile">Profile</string>
     <string name="route_settings">Settings</string>
     <string name="route_steps">Steps</string>


### PR DESCRIPTION
Implemented goal creation and view

- User can create weekly and monthly goals for activities that we deem likely to be autocompleted
- When user is creating a walking goal, they can choose between steps and distance. Otherwise they can only choose distance
- When creating a goal, the start date is always automatically chosen as today, if user choose to create a weekly goal - end date is 7 days from today, monthly - 30 days.
- Viewer can change dates for weekly/monthly goals they're viewing. Goal is shown if his end date or start date falls between the shown range.
- Once user creates a goal, it can not be deleted

Here's how the implementation currently looks:


<img src="https://github.com/PVP-K410/Calendar/assets/25864361/597ddbbb-230b-4f16-ac67-03a03917b850" width="50%">

<img src="https://github.com/PVP-K410/Calendar/assets/25864361/430adb39-88dd-4f7b-9875-3f20b15c99c2" 
width="50%">

<img src="https://github.com/PVP-K410/Calendar/assets/25864361/6953e645-e0f0-472f-a3b0-1b817c497727" 
width="50%">
