### PR TITLE
PVP-256 Adjust UI to have less dialogs, rework flows, add loading states

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@
         │               │   └── ...
         │               ├── model             # Data Models
         │               │   └── ...
+        │               ├── service           # Services
+        │               │   └── ...
         │               ├── ui
         │               │   ├── common        # Common Use: Components, Handlers, Utilities, ...
         │               │   │   └── ...
@@ -48,7 +50,7 @@
         │               │   │   └── ...
         │               │   └── theme         # Theme Configurations
         │               │       └── ...
-        │               ├── worker            # Background Workers
+        │               ├── worker            # Service Workers
         │               │   └── ...
         │               ├── Activity.kt
         │               └── Application.kt
@@ -76,20 +78,25 @@
 - Each model is located in a grouped by its use file. i.e. `Task.kt` could hold `Task`
   and `TaskMeal` models.
 
+###### ◽ src/main/.../service
+- Service is a layer that controls most things within this application.
+- Services handle database calls and business logic.
+- UI > ViewModel > Service > Database
+
 ###### ◽ src/main/.../ui
 - `Composable` functions (later on: `Components`) are used to build the UI.
 - `Screen` is just a component that is used to build the UI out of other components.
 - Screen components are located in `ui.screen` package.
 - Each screen has its own `Screen` component and `ViewModel` if required.
-- Components specific to a screen are located in the same file as the screen component.
+- Components specific to a screen are located in the same package as the screen component.
 - Components that are not specific to a screen are located in `ui.common` package, grouped by their
   use. i.e. `Texts.kt`, `Buttons.kt`, etc.
 - `Router` is used to define routes to screens.
 
 ###### ◽ src/main/.../worker
-- Background workers are located in `worker` package.
+- Service workers are located in `worker` package.
 - Each worker is located in a separate file.
-- Workers are used to perform background tasks.
+- Workers are used to perform background/foreground one-time/periodic tasks.
 
 ###### ◽ src/main/res
 - Resources are located in `res` directory.
@@ -105,7 +112,7 @@
     - Groups of the same type of code can stay together without an empty line
     - Multi-line code blocks should be separated by an empty line, even if they are of the same type
   - Use `val` instead of `var` whenever possible
-  - Use `when` instead of `if` whenever possible
+  - Use `when` instead of `if` whenever possible, unless there are only 2 outcomes (use `if` in that case)
   - Use brackets for `if`, `for` and `while` blocks even if they are not required
     - Exception for `if`: conditionals that are in a single line
   - Use simple yet well defined names for variables, functions, classes, etc.

--- a/app/projectStyles.xml
+++ b/app/projectStyles.xml
@@ -1,0 +1,132 @@
+<code_scheme name="Project" version="173">
+  <JetCodeStyleSettings>
+    <option name="BLANK_LINES_AROUND_BLOCK_WHEN_BRANCHES" value="1" />
+    <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+  </JetCodeStyleSettings>
+  <codeStyleSettings language="XML">
+    <option name="FORCE_REARRANGE_MODE" value="1" />
+    <indentOptions>
+      <option name="CONTINUATION_INDENT_SIZE" value="4" />
+    </indentOptions>
+    <arrangement>
+      <rules>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>xmlns:android</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>^$</XML_NAMESPACE>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>xmlns:.*</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>^$</XML_NAMESPACE>
+              </AND>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>.*:id</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>.*:name</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>name</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>^$</XML_NAMESPACE>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>style</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>^$</XML_NAMESPACE>
+              </AND>
+            </match>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>.*</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>^$</XML_NAMESPACE>
+              </AND>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>.*</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>http://schemas.android.com/apk/res/android</XML_NAMESPACE>
+              </AND>
+            </match>
+            <order>ANDROID_ATTRIBUTE_ORDER</order>
+          </rule>
+        </section>
+        <section>
+          <rule>
+            <match>
+              <AND>
+                <NAME>.*</NAME>
+                <XML_ATTRIBUTE />
+                <XML_NAMESPACE>.*</XML_NAMESPACE>
+              </AND>
+            </match>
+            <order>BY_NAME</order>
+          </rule>
+        </section>
+      </rules>
+    </arrangement>
+  </codeStyleSettings>
+  <codeStyleSettings language="kotlin">
+    <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
+    <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
+    <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
+    <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
+    <option name="BLANK_LINES_AFTER_CLASS_HEADER" value="1" />
+    <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
+    <option name="CALL_PARAMETERS_WRAP" value="2" />
+    <option name="METHOD_PARAMETERS_WRAP" value="2" />
+    <option name="METHOD_CALL_CHAIN_WRAP" value="2" />
+    <option name="WRAP_FIRST_METHOD_IN_CALL_CHAIN" value="true" />
+    <option name="ENUM_CONSTANTS_WRAP" value="2" />
+  </codeStyleSettings>
+</code_scheme>

--- a/app/src/main/java/com/pvp/app/common/FlowUtil.kt
+++ b/app/src/main/java/com/pvp/app/common/FlowUtil.kt
@@ -3,21 +3,24 @@ package com.pvp.app.common
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.flowOf
 
 object FlowUtil {
 
     /**
-     * Flattens a list of flows into a single flow of lists (**List<Flow<T>>** -> **Flow<List<T>>**).
+     * Flattens a list of flows into a single flow of list (**List<Flow<T>>** -> **Flow<List<T>>**).
      *
-     * In case of an empty list, it may lock the thread, since it will never emit a value and the
-     * implementation is based on [Flow.combine] principle, which requires at least one flow to emit
-     * a value.
+     * In case of an empty list, it straightforwardly returns flow of empty list.
      *
-     * @return A flow of combined flows lists.
+     * @return A flow of combined flows list.
      */
     inline fun <reified T : Any?> List<Flow<T>>.flattenFlow(): Flow<List<T>> =
-        combine(this@flattenFlow) {
-            it.toList()
+        if (isEmpty()) {
+            flowOf(emptyList())
+        } else {
+            combine(this@flattenFlow) {
+                it.toList()
+            }
         }
 
     /**

--- a/app/src/main/java/com/pvp/app/ui/common/Components.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Components.kt
@@ -210,6 +210,17 @@ fun ProgressIndicator(
 }
 
 @Composable
+fun ProgressIndicatorWithinDialog(
+    indicatorColor: Color = MaterialTheme.colorScheme.primary,
+    modifier: Modifier = Modifier.fillMaxSize()
+) = androidx.compose.ui.window.Dialog(onDismissRequest = {}) {
+    ProgressIndicator(
+        indicatorColor,
+        modifier
+    )
+}
+
+@Composable
 fun Experience(
     experience: Int,
     experienceRequired: Int,

--- a/app/src/main/java/com/pvp/app/ui/common/Extensions.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Extensions.kt
@@ -7,6 +7,27 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalDensity
 import androidx.core.graphics.ColorUtils
+import androidx.navigation.NavHostController
+
+/**
+ * Extension function to navigate to a route. This function will pop up to the start destination
+ * of the graph before navigating to the new route. This is to ensure that the back stack is cleared.
+ * State is saved and restored to ensure that the back stack is not lost.
+ *
+ * @param route The route to navigate to.
+ */
+fun @Composable NavHostController.navigateWithPopUp(route: String) {
+    val graph = this.graph
+
+    navigate(route) {
+        popUpTo(graph.startDestinationId) {
+            saveState = true
+        }
+
+        launchSingleTop = true
+        restoreState = true
+    }
+}
 
 fun <T : Context> T.showToast(
     duration: Int = Toast.LENGTH_LONG,

--- a/app/src/main/java/com/pvp/app/ui/common/Extensions.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Extensions.kt
@@ -2,8 +2,10 @@ package com.pvp.app.ui.common
 
 import android.content.Context
 import android.widget.Toast
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalDensity
 import androidx.core.graphics.ColorUtils
 
 fun <T : Context> T.showToast(
@@ -57,3 +59,6 @@ fun Color.lighten(
         )
         .run { Color(this) }
 }
+
+@Composable
+fun Int.pixelsToDp() = with(LocalDensity.current) { toDp() }

--- a/app/src/main/java/com/pvp/app/ui/common/Extensions.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Extensions.kt
@@ -2,33 +2,9 @@ package com.pvp.app.ui.common
 
 import android.content.Context
 import android.widget.Toast
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.core.graphics.ColorUtils
-import androidx.navigation.NavHostController
-
-/**
- * Extension function to navigate to a route. This function will pop up to the start destination
- * of the graph before navigating to the new route. This is to ensure that the back stack is cleared.
- * State is saved and restored to ensure that the back stack is not lost.
- *
- * @param route The route to navigate to.
- */
-fun @Composable NavHostController.navigateWithPopUp(route: String) {
-    val graph = this.graph
-
-    navigate(
-        route
-    ) {
-        popUpTo(graph.startDestinationId) {
-            saveState = true
-        }
-
-        launchSingleTop = true
-        restoreState = true
-    }
-}
 
 fun <T : Context> T.showToast(
     duration: Int = Toast.LENGTH_LONG,

--- a/app/src/main/java/com/pvp/app/ui/common/Locals.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Locals.kt
@@ -1,8 +1,30 @@
 package com.pvp.app.ui.common
 
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Color
+import com.pvp.app.ui.router.Route
 
+private fun notProvided(name: String): Nothing = error("No $name provided")
+
+/**
+ * Composition local for background colors
+ */
 val LocalBackgroundColors = staticCompositionLocalOf<List<Color>> {
-    error("No LocalBackgroundColors provided")
+    notProvided("LocalBackgroundColors")
+}
+
+/**
+ * Composition local for route options
+ */
+val LocalRouteOptions = staticCompositionLocalOf<Route.Options> {
+    notProvided("LocalRouteOptions")
+}
+
+/**
+ * Composition local for applying route options by using current route options
+ */
+val LocalRouteOptionsApplier = staticCompositionLocalOf<
+        @Composable ((options: Route.Options) -> Route.Options) -> Unit> {
+    notProvided("LocalRouteOptionsApplier")
 }

--- a/app/src/main/java/com/pvp/app/ui/common/Locals.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Locals.kt
@@ -15,6 +15,15 @@ val LocalBackgroundColors = staticCompositionLocalOf<List<Color>> {
 }
 
 /**
+ * Composition local for horizontal pager page being settled. This should be used to
+ * execute some actions only when the page scroll has been completed and the page is
+ * settled.
+ */
+val LocalHorizontalPagerSettled = staticCompositionLocalOf<Boolean> {
+    notProvided("LocalHorizontalPagerSettled")
+}
+
+/**
  * Composition local for route options
  */
 val LocalRouteOptions = staticCompositionLocalOf<Route.Options> {

--- a/app/src/main/java/com/pvp/app/ui/common/Pickers.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Pickers.kt
@@ -27,7 +27,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onSizeChanged
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import com.pvp.app.common.CollectionUtil.indexOfOrNull
@@ -66,7 +65,7 @@ fun <T> Picker(
     val stateList = rememberLazyListState(initialFirstVisibleItemIndex = indexStart)
     val flingBehavior = rememberSnapFlingBehavior(lazyListState = stateList)
     val itemHeightPixels = remember { mutableIntStateOf(0) }
-    val itemHeightDp = pixelsToDp(itemHeightPixels.intValue)
+    val itemHeightDp = itemHeightPixels.intValue.pixelsToDp()
 
     val fadingEdgeGradient = remember {
         Brush.verticalGradient(
@@ -202,6 +201,3 @@ fun PickerTime(
         visibleItemsCount = 3
     )
 }
-
-@Composable
-private fun pixelsToDp(pixels: Int) = with(LocalDensity.current) { pixels.toDp() }

--- a/app/src/main/java/com/pvp/app/ui/common/RouteComponents.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/RouteComponents.kt
@@ -1,0 +1,28 @@
+package com.pvp.app.ui.common
+
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.sp
+
+@Composable
+fun RouteIcon(
+    imageVector: ImageVector,
+    resourceId: Int
+) {
+    Icon(
+        contentDescription = "${stringResource(resourceId)} route button icon",
+        imageVector = imageVector
+    )
+}
+
+@Composable
+fun RouteTitle(title: String) {
+    Text(
+        style = MaterialTheme.typography.titleLarge.copy(fontSize = 24.sp),
+        text = title
+    )
+}

--- a/app/src/main/java/com/pvp/app/ui/common/RouteUtil.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/RouteUtil.kt
@@ -1,12 +1,7 @@
 package com.pvp.app.ui.common
 
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import androidx.navigation.NavBackStackEntry
@@ -29,24 +24,5 @@ object RouteUtil {
         }
 
         return hiltViewModel(parentEntry)
-    }
-
-    @Composable
-    fun RouteIcon(
-        imageVector: ImageVector,
-        resourceId: Int
-    ) {
-        androidx.compose.material3.Icon(
-            contentDescription = "${stringResource(resourceId)} route button icon",
-            imageVector = imageVector
-        )
-    }
-
-    @Composable
-    fun RouteTitle(title: String) {
-        Text(
-            style = MaterialTheme.typography.titleLarge.copy(fontSize = 24.sp),
-            text = title
-        )
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/common/RouteUtil.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/RouteUtil.kt
@@ -1,0 +1,52 @@
+package com.pvp.app.ui.common
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.navigation.NavBackStackEntry
+import androidx.navigation.NavController
+
+object RouteUtil {
+
+    /**
+     * If there is any routes in the backstack that had specified viewModel, it will be
+     * returned. Otherwise, it will return the viewModel of the current route.
+     */
+    @Composable
+    inline fun <reified T : ViewModel> NavBackStackEntry.hiltViewModel(
+        controller: NavController
+    ): T {
+        val navGraphRoute = destination.parent?.route ?: return hiltViewModel()
+
+        val parentEntry = remember(this) {
+            controller.getBackStackEntry(navGraphRoute)
+        }
+
+        return hiltViewModel(parentEntry)
+    }
+
+    @Composable
+    fun RouteIcon(
+        imageVector: ImageVector,
+        resourceId: Int
+    ) {
+        androidx.compose.material3.Icon(
+            contentDescription = "${stringResource(resourceId)} route button icon",
+            imageVector = imageVector
+        )
+    }
+
+    @Composable
+    fun RouteTitle(title: String) {
+        Text(
+            style = MaterialTheme.typography.titleLarge.copy(fontSize = 24.sp),
+            text = title
+        )
+    }
+}

--- a/app/src/main/java/com/pvp/app/ui/router/Router.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Router.kt
@@ -7,7 +7,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
-import androidx.navigation.compose.composable
 import kotlinx.coroutines.CoroutineScope
 
 @Composable
@@ -37,13 +36,12 @@ fun Router(
         startDestination = destinationStart.path
     ) {
         routes.forEach { r ->
-            composable(route = r.path) {
-                r.screen(
-                    controller,
-                    routeModifier,
-                    scope
-                )
-            }
+            r.builder(
+                this,
+                controller,
+                routeModifier,
+                scope
+            )
         }
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/router/Router.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Router.kt
@@ -1,5 +1,6 @@
 package com.pvp.app.ui.router
 
+import android.util.Log
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.EaseOut
 import androidx.compose.animation.core.LinearEasing
@@ -105,6 +106,12 @@ private fun NavGraphBuilder.composeRoute(
             LocalRouteOptionsApplier.current { route.options }
 
             applierRequired = false
+
+            // TODO: Delete in PR
+            Log.d(
+                "Applied options",
+                "-- ${route.path} --"
+            )
         }
 
         route.compose(

--- a/app/src/main/java/com/pvp/app/ui/router/Router.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Router.kt
@@ -85,7 +85,7 @@ private fun NavGraphBuilder.composeRoute(
         )
 
         LaunchedEffect(
-            backstack.destination,
+            backstack.destination.route,
             options
         ) {
             if (backstack.destination.route == route.path) {

--- a/app/src/main/java/com/pvp/app/ui/router/Router.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Router.kt
@@ -4,19 +4,22 @@ import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
-import kotlinx.coroutines.CoroutineScope
+import androidx.navigation.compose.composable
+import androidx.navigation.navigation
 
 @Composable
 fun Router(
     controller: NavHostController,
-    destinationStart: Route,
     modifier: Modifier = Modifier,
+    onConsumeOptions: (Route.Options) -> Unit = {},
     routeModifier: Modifier = Modifier,
     routes: List<Route>,
-    scope: CoroutineScope
+    start: Route
 ) {
     NavHost(
         enterTransition = {
@@ -33,15 +36,64 @@ fun Router(
         },
         modifier = modifier,
         navController = controller,
-        startDestination = destinationStart.path
-    ) {
-        routes.forEach { r ->
-            r.builder(
-                this,
-                controller,
-                routeModifier,
-                scope
-            )
+        startDestination = when (start) {
+            is Route.Root -> start.start.path
+            is Route.Node -> start.path
         }
+    ) {
+        routes.forEach { route ->
+            when (route) {
+                is Route.Node -> {
+                    composeRoute(
+                        controller,
+                        onConsumeOptions,
+                        route,
+                        routeModifier
+                    )
+                }
+
+                is Route.Root -> {
+                    navigation(
+                        route = route.path,
+                        startDestination = route.start.path
+                    ) {
+                        route.nodes.forEach { node ->
+                            composeRoute(
+                                controller,
+                                onConsumeOptions,
+                                node,
+                                routeModifier
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun NavGraphBuilder.composeRoute(
+    controller: NavHostController,
+    onConsumeOptions: (Route.Options) -> Unit,
+    route: Route.Node,
+    routeModifier: Modifier
+) {
+    composable(route.path) { backstack ->
+        val options = route.resolveOptions(
+            backstack,
+            controller
+        )
+
+        LaunchedEffect(backstack.destination.route) {
+            if (backstack.destination.route == route.path) {
+                onConsumeOptions(options)
+            }
+        }
+
+        route.compose(
+            backstack,
+            controller,
+            routeModifier
+        ) { onConsumeOptions(options) }
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/router/Router.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Router.kt
@@ -84,7 +84,10 @@ private fun NavGraphBuilder.composeRoute(
             controller
         )
 
-        LaunchedEffect(backstack.destination.route) {
+        LaunchedEffect(
+            backstack.destination,
+            options
+        ) {
             if (backstack.destination.route == route.path) {
                 onConsumeOptions(options)
             }

--- a/app/src/main/java/com/pvp/app/ui/router/Router.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Router.kt
@@ -1,6 +1,5 @@
 package com.pvp.app.ui.router
 
-import android.util.Log
 import androidx.compose.animation.AnimatedContentTransitionScope
 import androidx.compose.animation.core.EaseOut
 import androidx.compose.animation.core.LinearEasing
@@ -19,6 +18,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navigation
+import com.pvp.app.ui.common.LocalHorizontalPagerSettled
 import com.pvp.app.ui.common.LocalRouteOptionsApplier
 
 @Composable
@@ -100,18 +100,13 @@ private fun NavGraphBuilder.composeRoute(
     routeModifier: Modifier
 ) {
     composable(route.path) { backstack ->
-        var applierRequired by remember { mutableStateOf(false) }
+        val settled = LocalHorizontalPagerSettled.current
+        var applierRequired by remember(settled) { mutableStateOf(settled) }
 
         if (applierRequired) {
             LocalRouteOptionsApplier.current { route.options }
 
             applierRequired = false
-
-            // TODO: Delete in PR
-            Log.d(
-                "Applied options",
-                "-- ${route.path} --"
-            )
         }
 
         route.compose(

--- a/app/src/main/java/com/pvp/app/ui/router/Router.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Router.kt
@@ -1,5 +1,8 @@
 package com.pvp.app.ui.router
 
+import androidx.compose.animation.AnimatedContentTransitionScope
+import androidx.compose.animation.core.EaseOut
+import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -26,8 +29,34 @@ fun Router(
     start: Route
 ) {
     NavHost(
-        enterTransition = { fadeIn(tween(300)) },
-        exitTransition = { fadeOut(tween(300)) },
+        enterTransition = {
+            fadeIn(
+                animationSpec = tween(
+                    durationMillis = 300,
+                    easing = LinearEasing
+                )
+            ) + slideIntoContainer(
+                animationSpec = tween(
+                    durationMillis = 300,
+                    easing = EaseOut
+                ),
+                towards = AnimatedContentTransitionScope.SlideDirection.End
+            )
+        },
+        exitTransition = {
+            fadeOut(
+                animationSpec = tween(
+                    durationMillis = 300,
+                    easing = LinearEasing
+                )
+            ) + slideOutOfContainer(
+                animationSpec = tween(
+                    durationMillis = 300,
+                    easing = EaseOut
+                ),
+                towards = AnimatedContentTransitionScope.SlideDirection.Start
+            )
+        },
         modifier = modifier,
         navController = controller,
         startDestination = when (start) {

--- a/app/src/main/java/com/pvp/app/ui/router/Routes.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Routes.kt
@@ -8,7 +8,6 @@ import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Storefront
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -152,19 +151,17 @@ object Routes {
         // Options [Route.Node.options] are not defined here, because we are not using static values
         // of this route anywhere
         resolveOptions = { backstack, controller ->
-            val state by backstack
+            val username = backstack
                 .hiltViewModel<FriendsViewModel>(controller).stateFriend
-                .collectAsStateWithLifecycle()
+                .collectAsStateWithLifecycle().value.entry.user.username
 
-            val title = with(state.entry.user.username) {
-                if (isNotBlank()) {
-                    stringResource(
-                        R.string.route_friend,
-                        this
-                    )
-                } else {
-                    ""
-                }
+            val title = if (username.isNotBlank()) {
+                stringResource(
+                    R.string.route_friend,
+                    username
+                )
+            } else {
+                stringResource(R.string.route_friends)
             }
 
             Options(title = { RouteTitle(title) })

--- a/app/src/main/java/com/pvp/app/ui/router/Routes.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Routes.kt
@@ -8,18 +8,18 @@ import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Storefront
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
+import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavBackStackEntry
-import androidx.navigation.NavController
-import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.composable
-import androidx.navigation.navigation
 import com.pvp.app.R
+import com.pvp.app.ui.common.RouteUtil.RouteIcon
+import com.pvp.app.ui.common.RouteUtil.RouteTitle
+import com.pvp.app.ui.common.RouteUtil.hiltViewModel
+import com.pvp.app.ui.router.Route.Node
+import com.pvp.app.ui.router.Route.Root
 import com.pvp.app.ui.screen.authentication.AuthenticationScreen
 import com.pvp.app.ui.screen.calendar.CalendarScreen
 import com.pvp.app.ui.screen.decoration.DecorationScreen
@@ -29,183 +29,217 @@ import com.pvp.app.ui.screen.friends.FriendsViewModel
 import com.pvp.app.ui.screen.settings.SettingsScreen
 import com.pvp.app.ui.screen.steps.StepScreen
 import com.pvp.app.ui.screen.survey.SurveyScreen
-import kotlinx.coroutines.CoroutineScope
 
-sealed class Route(
-    val builder: NavGraphBuilder.(
-        controller: NavHostController,
-        modifier: Modifier,
-        scope: CoroutineScope
-    ) -> Unit,
-    val icon: ImageVector? = null,
-    val iconDescription: String? = null,
-    val path: String,
-    val resourceTitleId: Int
-) {
+sealed class Route(val path: String) {
 
-    data object Authentication : Route(
-        builder = { _, _, _ ->
-            composable("authentication") {
-                AuthenticationScreen()
-            }
-        },
-        path = "authentication",
-        resourceTitleId = R.string.empty,
+    open class Options(
+        val icon: (@Composable () -> Unit)? = null,
+        val title: (@Composable () -> Unit)? = null
+    ) {
+
+        data object None : Options()
+    }
+
+    sealed class Node(
+        val compose: @Composable (
+            backstack: NavBackStackEntry,
+            controller: NavHostController,
+            modifier: Modifier,
+            resolveOptions: () -> Unit
+        ) -> Unit,
+        val options: Options = Options.None,
+        path: String,
+        val resolveOptions: @Composable (
+            NavBackStackEntry,
+            NavHostController
+        ) -> Options = { _, _ -> options }
+    ) : Route(path)
+
+    sealed class Root(
+        val nodes: List<Node>,
+        path: String,
+        val start: Node
+    ) : Route(path)
+}
+
+object Routes {
+
+    /**
+     * These routes are used when user state is set to **authenticated** and all required
+     * surveys are filled.
+     *
+     * Routes are used within [com.pvp.app.ui.screen.layout.LayoutScreenAuthenticated] layout.
+     */
+    val routesAuthenticated = listOf(
+        Calendar,
+        Decorations,
+        FriendsRoot,
+        None,
+        Settings,
+        Steps
     )
 
-    data object Calendar : Route(
-        builder = { _, m, _ ->
-            composable("calendar") {
-                CalendarScreen(modifier = m)
-            }
-        },
-        icon = Icons.Outlined.CalendarMonth,
-        iconDescription = "Calendar page button icon",
-        path = "calendar",
-        resourceTitleId = R.string.route_calendar
+    /**
+     * These routes are used for simple navigation drawer implementation. Routes that are
+     * provided here, will be displayed in the navigation drawer. Navigation drawer is only
+     * available for authenticated users, hence all routes that are under this list should
+     * also be under [routesAuthenticated] list.
+     *
+     * Routes are used within [com.pvp.app.ui.screen.layout.LayoutScreenAuthenticated] layout.
+     */
+    val routesDrawer = listOf(
+        Calendar,
+        Decorations,
+        Friends,
+        Settings,
+        Steps
     )
 
-    data object Decorations : Route(
-        builder = { _, m, _ ->
-            composable("decorations") {
-                DecorationScreen(modifier = m)
-            }
-        },
-        icon = Icons.Outlined.Storefront,
-        iconDescription = "Decorations page button icon",
-        path = "decorations",
-        resourceTitleId = R.string.route_decorations
+    /**
+     * These routes are used when user state is set to **unauthenticated** or when user has
+     * any surveys that are not filled yet, but **must** be.
+     *
+     * Routes are used within [com.pvp.app.ui.screen.layout.LayoutScreenUnauthenticated] layout.
+     */
+    val routesUnauthenticated = listOf(
+        Authentication,
+        None,
+        Survey
     )
 
-    data object Friends : Route(
-        builder = { controller, modifier, _ ->
-            navigation(
-                route = "friendsGraph",
-                startDestination = "friends"
-            ) {
-                composable("friends") {
-                    FriendsScreen(
-                        controller = controller,
-                        model = it.hiltViewModel<FriendsViewModel>(controller),
-                        modifier = modifier
+    data object Authentication : Node(
+        compose = { _, _, _, _ -> AuthenticationScreen() },
+        path = "authentication"
+    )
+
+    data object Calendar : Node(
+        compose = { _, _, m, _ -> CalendarScreen(modifier = m) },
+        options = Options(
+            icon = {
+                RouteIcon(
+                    imageVector = Icons.Outlined.CalendarMonth,
+                    resourceId = R.string.route_calendar
+                )
+            },
+            title = { RouteTitle(stringResource(R.string.route_calendar)) }
+        ),
+        path = "calendar"
+    )
+
+    data object Decorations : Node(
+        compose = { _, _, m, _ -> DecorationScreen(modifier = m) },
+        options = Options(
+            icon = {
+                RouteIcon(
+                    imageVector = Icons.Outlined.Storefront,
+                    resourceId = R.string.route_decorations
+                )
+            },
+            title = { RouteTitle(stringResource(R.string.route_decorations)) }
+        ),
+        path = "decorations"
+    )
+
+    data object Friend : Node(
+        compose = { backstack, controller, modifier, resolveOptions ->
+            FriendScreen(
+                controller = controller,
+                model = backstack.hiltViewModel<FriendsViewModel>(controller),
+                modifier = modifier,
+                resolveOptions = resolveOptions
+            )
+        },
+        // Options [Route.Node.options] are not defined here, because we are not using static values
+        // of this route anywhere
+        resolveOptions = { backstack, controller ->
+            val state by backstack
+                .hiltViewModel<FriendsViewModel>(controller).stateFriend
+                .collectAsStateWithLifecycle()
+
+            val title = with(state.entry.user.username) {
+                if (isNotBlank()) {
+                    stringResource(
+                        R.string.route_friend,
+                        this
                     )
-                }
-
-                composable("friend") {
-                    FriendScreen(
-                        model = it.hiltViewModel<FriendsViewModel>(controller),
-                        modifier = modifier
-                    )
+                } else {
+                    ""
                 }
             }
+
+            Options(title = { RouteTitle(title) })
         },
-        icon = Icons.Outlined.People,
-        iconDescription = "Friends page button icon",
-        path = "friendsGraph",
-        resourceTitleId = R.string.route_friends
+        path = "friend"
     )
 
-    data object None : Route(
-        builder = { _, _, _ -> composable("none") { } },
-        path = "none",
-        resourceTitleId = R.string.empty
+    data object Friends : Node(
+        compose = { backstack, controller, modifier, _ ->
+            FriendsScreen(
+                controller = controller,
+                model = backstack.hiltViewModel<FriendsViewModel>(controller),
+                modifier = modifier
+            )
+        },
+        options = Options(
+            icon = {
+                RouteIcon(
+                    imageVector = Icons.Outlined.People,
+                    resourceId = R.string.route_friends
+                )
+            },
+            title = { RouteTitle(stringResource(R.string.route_friends)) }
+        ),
+        path = "friends"
     )
 
-    data object Settings : Route(
-        builder = { _, m, _ ->
-            composable("settings") {
-                SettingsScreen(modifier = m)
-            }
-        },
-        icon = Icons.Outlined.Settings,
-        iconDescription = "Settings page button icon",
-        path = "settings",
-        resourceTitleId = R.string.route_settings
+    data object FriendsRoot : Root(
+        nodes = listOf(
+            Friend,
+            Friends
+        ),
+        path = "friends-root",
+        start = Friends
+    )
+
+    data object None : Node(
+        compose = { _, _, _, _ -> },
+        path = "none"
+    )
+
+    data object Settings : Node(
+        compose = { _, _, m, _ -> SettingsScreen(modifier = m) },
+        options = Options(
+            icon = {
+                RouteIcon(
+                    imageVector = Icons.Outlined.Settings,
+                    resourceId = R.string.route_settings
+                )
+            },
+            title = { RouteTitle(stringResource(R.string.route_settings)) }
+        ),
+        path = "settings"
     )
 
     @SuppressLint("NewApi")
-    data object Steps : Route(
-        builder = { _, m, _ ->
-            composable("steps") {
-                StepScreen(modifier = m)
-            }
-        },
-        icon = Icons.AutoMirrored.Outlined.DirectionsWalk,
-        iconDescription = "Step counter page button icon",
-        path = "steps",
-        resourceTitleId = R.string.route_steps
+    data object Steps : Node(
+        compose = { _, _, m, _ -> StepScreen(modifier = m) },
+        options = Options(
+            icon = {
+                RouteIcon(
+                    imageVector = Icons.AutoMirrored.Outlined.DirectionsWalk,
+                    resourceId = R.string.route_steps
+                )
+            },
+            title = { RouteTitle(stringResource(R.string.route_steps)) }
+        ),
+        path = "steps"
     )
 
-    data object Survey : Route(
-        builder = { _, _, _ ->
-            composable("survey") {
-                SurveyScreen()
-            }
-        },
-        path = "survey",
-        resourceTitleId = R.string.route_survey
+    data object Survey : Node(
+        compose = { _, _, _, _ -> SurveyScreen() },
+        options = Options(
+            title = { RouteTitle(stringResource(R.string.route_survey)) }
+        ),
+        path = "survey"
     )
-
-    companion object {
-
-        /**
-         * These routes are used when user state is set to **authenticated** and all required
-         * surveys are filled.
-         *
-         * Routes are used within [com.pvp.app.ui.screen.layout.LayoutScreenAuthenticated] layout.
-         */
-        val routesAuthenticated = listOf(
-            Calendar,
-            Decorations,
-            Friends,
-            None,
-            Settings,
-            Steps
-        )
-
-        /**
-         * These routes are used for simple navigation drawer implementation. Routes that are
-         * provided here, will be displayed in the navigation drawer. Navigation drawer is only
-         * available for authenticated users, hence all routes that are under this list should
-         * also be under [routesAuthenticated] list.
-         *
-         * Routes are used within [com.pvp.app.ui.screen.layout.LayoutScreenAuthenticated] layout.
-         */
-        val routesDrawer = listOf(
-            Calendar,
-            Decorations,
-            Friends,
-            Settings,
-            Steps
-        )
-
-        /**
-         * These routes are used when user state is set to **unauthenticated** or when user has
-         * any surveys that are not filled yet, but **must** be.
-         *
-         * Routes are used within [com.pvp.app.ui.screen.layout.LayoutScreenUnauthenticated] layout.
-         */
-        val routesUnauthenticated = listOf(
-            Authentication,
-            None,
-            Survey
-        )
-
-        /**
-         * If there is any routes in the backstack that had specified viewModel, it will be
-         * returned. Otherwise, it will return the viewModel of the current route.
-         */
-        @Composable
-        private inline fun <reified T : ViewModel> NavBackStackEntry.hiltViewModel(
-            controller: NavController
-        ): T {
-            val navGraphRoute = destination.parent?.route ?: return hiltViewModel()
-
-            val parentEntry = remember(this) {
-                controller.getBackStackEntry(navGraphRoute)
-            }
-
-            return hiltViewModel(parentEntry)
-        }
-    }
 }

--- a/app/src/main/java/com/pvp/app/ui/router/Routes.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Routes.kt
@@ -170,11 +170,12 @@ object Routes {
     )
 
     data object Friends : Node(
-        compose = { backstack, controller, modifier, _ ->
+        compose = { backstack, controller, modifier, resolveOptions ->
             FriendsScreen(
                 controller = controller,
                 model = backstack.hiltViewModel<FriendsViewModel>(controller),
-                modifier = modifier
+                modifier = modifier,
+                resolveOptions = resolveOptions
             )
         },
         options = Options(

--- a/app/src/main/java/com/pvp/app/ui/router/Routes.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Routes.kt
@@ -14,8 +14,8 @@ import androidx.compose.ui.res.stringResource
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import com.pvp.app.R
-import com.pvp.app.ui.common.RouteUtil.RouteIcon
-import com.pvp.app.ui.common.RouteUtil.RouteTitle
+import com.pvp.app.ui.common.RouteIcon
+import com.pvp.app.ui.common.RouteTitle
 import com.pvp.app.ui.common.RouteUtil.hiltViewModel
 import com.pvp.app.ui.router.Route.Node
 import com.pvp.app.ui.router.Route.Root
@@ -68,7 +68,7 @@ object Routes {
      *
      * Routes are used within [com.pvp.app.ui.screen.layout.LayoutScreenAuthenticated] layout.
      */
-    val routesAuthenticated = listOf(
+    val authenticated = listOf(
         Calendar,
         Decorations,
         FriendsRoot,
@@ -82,11 +82,11 @@ object Routes {
      * These routes are used for simple navigation drawer implementation. Routes that are
      * provided here, will be displayed in the navigation drawer. Navigation drawer is only
      * available for authenticated users, hence all routes that are under this list should
-     * also be under [routesAuthenticated] list.
+     * also be under [authenticated] list.
      *
      * Routes are used within [com.pvp.app.ui.screen.layout.LayoutScreenAuthenticated] layout.
      */
-    val routesDrawer = listOf(
+    val drawer = listOf(
         Calendar,
         Decorations,
         Friends,
@@ -101,7 +101,7 @@ object Routes {
      *
      * Routes are used within [com.pvp.app.ui.screen.layout.LayoutScreenUnauthenticated] layout.
      */
-    val routesUnauthenticated = listOf(
+    val unauthenticated = listOf(
         Authentication,
         None,
         Survey

--- a/app/src/main/java/com/pvp/app/ui/router/Routes.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Routes.kt
@@ -10,7 +10,6 @@ import androidx.compose.material.icons.outlined.Storefront
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavBackStackEntry
 import androidx.navigation.NavHostController
 import com.pvp.app.R
@@ -31,27 +30,25 @@ import com.pvp.app.ui.screen.survey.SurveyScreen
 
 sealed class Route(val path: String) {
 
-    open class Options(
+    data class Options(
         val icon: (@Composable () -> Unit)? = null,
         val title: (@Composable () -> Unit)? = null
     ) {
 
-        data object None : Options()
+        companion object {
+
+            val None = Options()
+        }
     }
 
     sealed class Node(
         val compose: @Composable (
             backstack: NavBackStackEntry,
             controller: NavHostController,
-            modifier: Modifier,
-            resolveOptions: () -> Unit
+            modifier: Modifier
         ) -> Unit,
         val options: Options = Options.None,
-        path: String,
-        val resolveOptions: @Composable (
-            NavBackStackEntry,
-            NavHostController
-        ) -> Options = { _, _ -> options }
+        path: String
     ) : Route(path)
 
     sealed class Root(
@@ -107,12 +104,12 @@ object Routes {
     )
 
     data object Authentication : Node(
-        compose = { _, _, _, _ -> AuthenticationScreen() },
+        compose = { _, _, _ -> AuthenticationScreen() },
         path = "authentication"
     )
 
     data object Calendar : Node(
-        compose = { _, _, m, _ -> CalendarScreen(modifier = m) },
+        compose = { _, _, m -> CalendarScreen(modifier = m) },
         options = Options(
             icon = {
                 RouteIcon(
@@ -126,7 +123,7 @@ object Routes {
     )
 
     data object Decorations : Node(
-        compose = { _, _, m, _ -> DecorationScreen(modifier = m) },
+        compose = { _, _, m -> DecorationScreen(modifier = m) },
         options = Options(
             icon = {
                 RouteIcon(
@@ -140,42 +137,25 @@ object Routes {
     )
 
     data object Friend : Node(
-        compose = { backstack, controller, modifier, resolveOptions ->
+        compose = { backstack, controller, modifier ->
             FriendScreen(
                 controller = controller,
                 model = backstack.hiltViewModel<FriendsViewModel>(controller),
-                modifier = modifier,
-                resolveOptions = resolveOptions
+                modifier = modifier
             )
         },
-        // Options [Route.Node.options] are not defined here, because we are not using static values
-        // of this route anywhere
-        resolveOptions = { backstack, controller ->
-            val username = backstack
-                .hiltViewModel<FriendsViewModel>(controller).stateFriend
-                .collectAsStateWithLifecycle().value.entry.user.username
-
-            val title = if (username.isNotBlank()) {
-                stringResource(
-                    R.string.route_friend,
-                    username
-                )
-            } else {
-                stringResource(R.string.route_friends)
-            }
-
-            Options(title = { RouteTitle(title) })
-        },
+        options = Options(
+            title = { RouteTitle(stringResource(R.string.route_friends)) }
+        ),
         path = "friend"
     )
 
     data object Friends : Node(
-        compose = { backstack, controller, modifier, resolveOptions ->
+        compose = { backstack, controller, modifier ->
             FriendsScreen(
                 controller = controller,
                 model = backstack.hiltViewModel<FriendsViewModel>(controller),
-                modifier = modifier,
-                resolveOptions = resolveOptions
+                modifier = modifier
             )
         },
         options = Options(
@@ -200,12 +180,12 @@ object Routes {
     )
 
     data object None : Node(
-        compose = { _, _, _, _ -> },
+        compose = { _, _, _ -> },
         path = "none"
     )
 
     data object Settings : Node(
-        compose = { _, _, m, _ -> SettingsScreen(modifier = m) },
+        compose = { _, _, m -> SettingsScreen(modifier = m) },
         options = Options(
             icon = {
                 RouteIcon(
@@ -220,7 +200,7 @@ object Routes {
 
     @SuppressLint("NewApi")
     data object Steps : Node(
-        compose = { _, _, m, _ -> StepScreen(modifier = m) },
+        compose = { _, _, m -> StepScreen(modifier = m) },
         options = Options(
             icon = {
                 RouteIcon(
@@ -234,7 +214,7 @@ object Routes {
     )
 
     data object Survey : Node(
-        compose = { _, _, _, _ -> SurveyScreen() },
+        compose = { _, _, _ -> SurveyScreen() },
         options = Options(
             title = { RouteTitle(stringResource(R.string.route_survey)) }
         ),

--- a/app/src/main/java/com/pvp/app/ui/router/Routes.kt
+++ b/app/src/main/java/com/pvp/app/ui/router/Routes.kt
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.DirectionsWalk
 import androidx.compose.material.icons.outlined.CalendarMonth
+import androidx.compose.material.icons.outlined.EmojiEvents
 import androidx.compose.material.icons.outlined.People
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Storefront
@@ -24,6 +25,7 @@ import com.pvp.app.ui.screen.decoration.DecorationScreen
 import com.pvp.app.ui.screen.friends.FriendScreen
 import com.pvp.app.ui.screen.friends.FriendsScreen
 import com.pvp.app.ui.screen.friends.FriendsViewModel
+import com.pvp.app.ui.screen.goals.GoalScreen
 import com.pvp.app.ui.screen.settings.SettingsScreen
 import com.pvp.app.ui.screen.steps.StepScreen
 import com.pvp.app.ui.screen.survey.SurveyScreen
@@ -70,6 +72,7 @@ object Routes {
         Calendar,
         Decorations,
         FriendsRoot,
+        Goals,
         None,
         Settings,
         Steps
@@ -87,6 +90,7 @@ object Routes {
         Calendar,
         Decorations,
         Friends,
+        Goals,
         Settings,
         Steps
     )
@@ -177,6 +181,20 @@ object Routes {
         ),
         path = "friends-root",
         start = Friends
+    )
+
+    data object Goals : Node(
+        compose = { _, _, m -> GoalScreen(modifier = m) },
+        options = Options(
+            icon = {
+                RouteIcon(
+                    imageVector = Icons.Outlined.EmojiEvents,
+                    resourceId = R.string.route_goals
+                )
+            },
+            title = { RouteTitle(stringResource(R.string.route_goals)) }
+        ),
+        path = "goals"
     )
 
     data object None : Node(

--- a/app/src/main/java/com/pvp/app/ui/screen/authentication/AuthenticationViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/authentication/AuthenticationViewModel.kt
@@ -7,6 +7,7 @@ import androidx.lifecycle.viewModelScope
 import com.pvp.app.api.AuthenticationService
 import com.pvp.app.model.AuthenticationResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -26,7 +27,7 @@ class AuthenticationViewModel @Inject constructor(
         isOneTap: Boolean,
         onAuthenticate: suspend (AuthenticationResult) -> Unit = {}
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             _state.update { it.copy(isLoading = true) }
 
             authenticationService
@@ -44,7 +45,7 @@ class AuthenticationViewModel @Inject constructor(
         launcher: (Intent) -> Unit,
         launcherOneTap: (IntentSenderRequest) -> Unit
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             try {
                 _state.update { it.copy(isLoading = true) }
 
@@ -72,7 +73,8 @@ class AuthenticationViewModel @Inject constructor(
     private suspend fun buildSignInRequestOneTap(): IntentSenderRequest? {
         val sender = authenticationService.beginSignInOneTap() ?: return null
 
-        return IntentSenderRequest.Builder(sender)
+        return IntentSenderRequest
+            .Builder(sender)
             .build()
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/AnalysesOfDay.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/AnalysesOfDay.kt
@@ -116,7 +116,7 @@ fun AnalysisOfDay(
                 Text(
                     fontSize = 18.sp,
                     modifier = Modifier.align(Alignment.CenterHorizontally),
-                    text = "Today's tasks"
+                    text = if (date == LocalDate.now()) "Today's tasks" else "Day's tasks"
                 )
 
                 HorizontalDivider(

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarMonthlyScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarMonthlyScreen.kt
@@ -78,7 +78,7 @@ private fun Content(
             )
 
             if (showDialog) {
-                TaskCreateSheetContent(
+                TaskCreateSheet(
                     date,
                     onChangeShowDialog
                 )
@@ -86,7 +86,7 @@ private fun Content(
         }
 
         tasks.isEmpty() && !date.isBefore(LocalDate.now()) -> {
-            TaskCreateSheetContent(
+            TaskCreateSheet(
                 date,
                 onChangeExpand
             )
@@ -380,11 +380,11 @@ private fun Header(
 }
 
 @Composable
-private fun TaskCreateSheetContent(
+private fun TaskCreateSheet(
     selectedDate: LocalDate,
     onClose: (Boolean) -> Unit
 ) {
-    TaskCreateSheetContent(
+    TaskCreateSheet(
         date = LocalDateTime.of(
             selectedDate,
             LocalTime.now()

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarMonthlyScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarMonthlyScreen.kt
@@ -78,7 +78,7 @@ private fun Content(
             )
 
             if (showDialog) {
-                TaskCreateDialog(
+                TaskCreateSheetContent(
                     date,
                     onChangeShowDialog
                 )
@@ -86,7 +86,7 @@ private fun Content(
         }
 
         tasks.isEmpty() && !date.isBefore(LocalDate.now()) -> {
-            TaskCreateDialog(
+            TaskCreateSheetContent(
                 date,
                 onChangeExpand
             )
@@ -380,11 +380,11 @@ private fun Header(
 }
 
 @Composable
-private fun TaskCreateDialog(
+private fun TaskCreateSheetContent(
     selectedDate: LocalDate,
     onClose: (Boolean) -> Unit
 ) {
-    TaskCreateDialog(
+    TaskCreateSheetContent(
         date = LocalDateTime.of(
             selectedDate,
             LocalTime.now()

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarMonthlyViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarMonthlyViewModel.kt
@@ -10,10 +10,12 @@ import com.pvp.app.common.DateUtil.getDays
 import com.pvp.app.common.TaskUtil.sort
 import com.pvp.app.model.Task
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -33,7 +35,7 @@ class CalendarMonthlyViewModel @Inject constructor(
     val state: StateFlow<CalendarUiState> = _state.asStateFlow()
 
     init {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             val flowUser = userService.user.filterNotNull()
 
             val flowTasks = flowUser.flatMapLatest { user ->
@@ -50,7 +52,7 @@ class CalendarMonthlyViewModel @Inject constructor(
                         )
                     )
                 }
-                .collect { state ->
+                .collectLatest { state ->
                     _state.update { stateOld ->
                         stateOld.copy(
                             tasks = state.tasks,

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
@@ -1,23 +1,62 @@
 package com.pvp.app.ui.screen.calendar
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun CalendarScreen(modifier: Modifier) {
+    var isDialogOpen by remember { mutableStateOf(false) }
+    val toggleDialog = remember { { isDialogOpen = !isDialogOpen } }
+
     val state = rememberPagerState(
         pageCount = { 2 },
         initialPage = 1
     )
 
-    VerticalPager(state = state) { page ->
-        when (page) {
-            0 -> CalendarMonthlyScreen(modifier = modifier)
-            1 -> CalendarWeeklyScreen(modifier = modifier)
+    Box {
+        VerticalPager(state = state) { page ->
+            when (page) {
+                0 -> CalendarMonthlyScreen(modifier = modifier)
+                1 -> CalendarWeeklyScreen(modifier = modifier)
+            }
         }
+
+        FloatingActionButton(
+            containerColor = MaterialTheme.colorScheme.primary,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .padding(16.dp),
+            onClick = toggleDialog,
+            shape = CircleShape
+        ) {
+            Icon(
+                contentDescription = "Create task",
+                imageVector = Icons.Outlined.Add
+            )
+        }
+
+        TaskCreateDialog(
+            onClose = toggleDialog,
+            isOpen = isDialogOpen,
+            shouldCloseOnSubmit = true
+        )
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
@@ -58,7 +58,7 @@ fun CalendarScreen(modifier: Modifier) {
             )
         }
 
-        TaskCreateSheetContent(
+        TaskCreateSheet(
             onClose = toggle,
             isOpen = isOpen,
             shouldCloseOnSubmit = true

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarScreen.kt
@@ -1,3 +1,8 @@
+@file:OptIn(
+    ExperimentalFoundationApi::class,
+    ExperimentalMaterial3Api::class
+)
+
 package com.pvp.app.ui.screen.calendar
 
 import androidx.compose.foundation.ExperimentalFoundationApi
@@ -8,6 +13,7 @@ import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Add
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -20,11 +26,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun CalendarScreen(modifier: Modifier) {
-    var isDialogOpen by remember { mutableStateOf(false) }
-    val toggleDialog = remember { { isDialogOpen = !isDialogOpen } }
+    var isOpen by remember { mutableStateOf(false) }
+    val toggle = remember { { isOpen = !isOpen } }
 
     val state = rememberPagerState(
         pageCount = { 2 },
@@ -44,7 +49,7 @@ fun CalendarScreen(modifier: Modifier) {
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(16.dp),
-            onClick = toggleDialog,
+            onClick = toggle,
             shape = CircleShape
         ) {
             Icon(
@@ -53,9 +58,9 @@ fun CalendarScreen(modifier: Modifier) {
             )
         }
 
-        TaskCreateDialog(
-            onClose = toggleDialog,
-            isOpen = isDialogOpen,
+        TaskCreateSheetContent(
+            onClose = toggle,
+            isOpen = isOpen,
             shouldCloseOnSubmit = true
         )
     }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
@@ -45,7 +45,7 @@ fun Week(
     val today = LocalDate.now()
     val startOfWeek = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
     val dates = (0..6).map { startOfWeek.plusDays(it.toLong()) }
-    var stateDialog by remember { mutableStateOf(false) }
+    var stateShowSheet by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
 
     val statePager = rememberPagerState(
@@ -78,7 +78,7 @@ fun Week(
                         }
                     } else {
                         if (tasksFiltered.isEmpty()) {
-                            stateDialog = true
+                            stateShowSheet = true
                         } else {
                             stateShowCards = !stateShowCards
                         }
@@ -100,13 +100,13 @@ fun Week(
             TasksOfDay(tasksFiltered)
         }
 
-        TaskCreateDialog(
+        TaskCreateSheetContent(
             date = date.atTime(
                 0,
                 0
             ),
-            isOpen = stateDialog,
-            onClose = { stateDialog = false },
+            isOpen = stateShowSheet,
+            onClose = { stateShowSheet = false },
             shouldCloseOnSubmit = true
         )
     }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyScreen.kt
@@ -100,7 +100,7 @@ fun Week(
             TasksOfDay(tasksFiltered)
         }
 
-        TaskCreateSheetContent(
+        TaskCreateSheet(
             date = date.atTime(
                 0,
                 0

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/CalendarWeeklyViewModel.kt
@@ -19,9 +19,11 @@ import com.pvp.app.common.TaskUtil.sort
 import com.pvp.app.model.Task
 import com.pvp.app.model.User
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
@@ -47,7 +49,7 @@ class CalendarWeeklyViewModel @Inject constructor(
     val state = _state.asStateFlow()
 
     init {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             val flowUser = userService.user.filterNotNull()
 
             val flowTasks = flowUser.flatMapLatest { user ->
@@ -69,7 +71,7 @@ class CalendarWeeklyViewModel @Inject constructor(
                         user = user
                     )
                 }
-                .collect { state -> _state.update { state } }
+                .collectLatest { state -> _state.update { state } }
         }
     }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
@@ -49,7 +49,7 @@ fun TaskCard(
     var showDialog by remember { mutableStateOf(false) }
 
     if (showDialog) {
-        TaskEditDialog(
+        TaskEditSheet(
             task,
             onDialogClose = {
                 showDialog = false

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
@@ -27,10 +27,10 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.pvp.app.model.SportActivity
 import com.pvp.app.model.SportTask
 import com.pvp.app.ui.common.EditableInfoItem
+import com.pvp.app.ui.common.InfoTooltip
 import com.pvp.app.ui.common.LabelFieldWrapper
 import com.pvp.app.ui.common.PickerPair
 import com.pvp.app.ui.common.PickerState
-import com.pvp.app.ui.common.InfoTooltip
 import java.time.Duration
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -42,7 +42,7 @@ fun TaskEditFieldsSport(
     onDistanceChange: (Double) -> Unit,
     onDurationChange: (Duration) -> Unit
 ) {
-    var activity by remember { mutableStateOf(task?.activity) }
+    var activity by remember { mutableStateOf(task?.activity ?: SportActivity.Walking) }
     var distance by remember { mutableDoubleStateOf(task?.distance ?: 0.0) }
     var duration by remember { mutableStateOf(task?.duration ?: Duration.ZERO) }
     var tempActivity by remember { mutableStateOf(activity) }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.pvp.app.ui.screen.calendar
 
 import androidx.compose.foundation.background
@@ -12,13 +14,16 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Place
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Slider
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -31,7 +36,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportActivity
@@ -69,7 +73,7 @@ private fun TaskTypeSelector(
 }
 
 @Composable
-fun TaskCreateDialog(
+fun TaskCreateSheetContent(
     date: LocalDateTime? = null,
     onClose: () -> Unit,
     isOpen: Boolean,
@@ -79,7 +83,10 @@ fun TaskCreateDialog(
         return
     }
 
-    Dialog(onDismissRequest = onClose) {
+    ModalBottomSheet(
+        onDismissRequest = onClose,
+        sheetState = rememberModalBottomSheetState()
+    ) {
         Column(
             modifier = Modifier
                 .fillMaxWidth()
@@ -353,7 +360,10 @@ fun TaskCreateForm(
                 onDismiss = { editingReminderTime = reminderTime },
                 value = if (reminderTime != null)
                     "${reminderTime?.toMinutes()} ${
-                        if (reminderTime?.toMinutes()?.toInt() == 1) "minute" else "minutes"
+                        if (reminderTime
+                                ?.toMinutes()
+                                ?.toInt() == 1
+                        ) "minute" else "minutes"
                     } before task" else ""
             )
 

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsEdit.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsEdit.kt
@@ -1,23 +1,26 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
 package com.pvp.app.ui.screen.calendar
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Slider
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -26,10 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.window.Dialog
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportTask
@@ -38,6 +38,7 @@ import com.pvp.app.ui.common.Button
 import com.pvp.app.ui.common.ButtonConfirm
 import com.pvp.app.ui.common.EditableDateItem
 import com.pvp.app.ui.common.EditableInfoItem
+import com.pvp.app.ui.common.Picker
 import com.pvp.app.ui.common.PickerState.Companion.rememberPickerState
 import com.pvp.app.ui.common.PickerTime
 import java.time.Duration
@@ -45,7 +46,7 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 @Composable
-fun TaskEditDialog(
+fun TaskEditSheet(
     task: Task,
     onDialogClose: () -> Unit,
     model: TaskViewModel = hiltViewModel()
@@ -69,269 +70,240 @@ fun TaskEditDialog(
         else -> "Description"
     }
 
-    Dialog(onDismissRequest = onDialogClose) {
-        Surface(
-            shape = RoundedCornerShape(10.dp),
-            color = MaterialTheme.colorScheme.surfaceContainer,
+    ModalBottomSheet(
+        onDismissRequest = onDialogClose,
+        sheetState = rememberModalBottomSheetState(true)
+    ) {
+        Column(
+            modifier = Modifier
+                .background(MaterialTheme.colorScheme.surfaceContainer)
+                .verticalScroll(rememberScrollState())
+                .padding(8.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
         ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        end = 15.dp,
-                        start = 15.dp,
-                        top = 15.dp
-                    )
-                    .verticalScroll(rememberScrollState()),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
-            ) {
-                EditableInfoItem(
-                    dialogContent = {
-                        OutlinedTextField(
-                            label = { Text("Title") },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(bottom = 16.dp),
-                            onValueChange = { newText ->
-                                tempTitle = newText
-                            },
-                            value = tempTitle
-                        )
-                    },
-                    dialogTitle = { Text("Editing title") },
-                    label = "Title",
-                    onConfirm = { title = tempTitle },
-                    onDismiss = { tempTitle = title },
-                    value = title
-                )
-
-                EditableInfoItem(
-                    dialogContent = {
-                        OutlinedTextField(
-                            label = { Text(descriptionLabel) },
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(bottom = 16.dp),
-                            onValueChange = { newText ->
-                                tempDescription = newText
-                            },
-                            value = tempDescription ?: ""
-                        )
-                    },
-                    dialogTitle = { Text("Editing $descriptionLabel") },
-                    label = descriptionLabel,
-                    onConfirm = { description = tempDescription },
-                    onDismiss = { tempDescription = description },
-                    value = description ?: ""
-                )
-
-                when (task) {
-                    is SportTask -> TaskEditFieldsSport(
-                        task = task,
-                        onActivityChange = { newActivity ->
-                            activity = newActivity
+            EditableInfoItem(
+                dialogContent = {
+                    OutlinedTextField(
+                        label = { Text("Title") },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 16.dp),
+                        onValueChange = { newText ->
+                            tempTitle = newText
                         },
-                        onDistanceChange = { newDistance ->
-                            distance = newDistance
-                        },
-                        onDurationChange = { newDuration ->
-                            duration = newDuration
-                        }
+                        value = tempTitle
                     )
+                },
+                dialogTitle = { Text("Editing title") },
+                label = "Title",
+                onConfirm = { title = tempTitle },
+                onDismiss = { tempTitle = title },
+                value = title
+            )
 
-                    else -> {}
-                }
-
-                if (task !is SportTask) {
-                    EditableInfoItem(
-                        dialogContent = {
-                            Column {
-                                Text(
-                                    text = "Duration: ${tempDuration?.toMinutes()} minutes",
-                                    style = TextStyle(fontSize = 16.sp),
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(start = 4.dp)
-                                )
-
-                                Slider(
-                                    value = tempDuration
-                                        ?.toMinutes()
-                                        ?.toFloat() ?: 0f,
-                                    onValueChange = { newValue ->
-                                        tempDuration = Duration.ofMinutes(newValue.toLong())
-                                    },
-                                    valueRange = 1f..180f, // TODO: take range from configuration
-                                    steps = 180,
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(
-                                            start = 8.dp,
-                                            end = 8.dp,
-                                            bottom = 8.dp
-                                        )
-                                )
-                            }
+            EditableInfoItem(
+                dialogContent = {
+                    OutlinedTextField(
+                        label = { Text(descriptionLabel) },
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 16.dp),
+                        onValueChange = { newText ->
+                            tempDescription = newText
                         },
-                        dialogTitle = { Text("Editing duration") },
-                        label = "Duration",
-                        onConfirm = { duration = tempDuration },
-                        onDismiss = { tempDuration = duration },
-                        value = "${duration?.toMinutes()} minutes"
+                        value = tempDescription ?: ""
                     )
-                }
+                },
+                dialogTitle = { Text("Editing $descriptionLabel") },
+                label = descriptionLabel,
+                onConfirm = { description = tempDescription },
+                onDismiss = { tempDescription = description },
+                value = description ?: ""
+            )
 
-                EditableInfoItem(
-                    dialogContent = {
-                        PickerTime(
-                            selectedHour = tempHour,
-                            selectedMinute = tempMinute,
-                            onChange = { hour, minute ->
-                                tempHour.value = hour
-                                tempMinute.value = minute
-                            }
-                        )
+            if (task is SportTask) {
+                TaskEditFieldsSport(
+                    task = task,
+                    onActivityChange = { newActivity ->
+                        activity = newActivity
                     },
-                    dialogTitle = { Text("Editing scheduled at") },
-                    label = "Scheduled at",
-                    onConfirm = {
-                        time = time
-                            .withHour(tempHour.value)
-                            .withMinute(tempMinute.value)
+                    onDistanceChange = { newDistance ->
+                        distance = newDistance
                     },
-                    onDismiss = {
-                        tempHour.value = time.hour
-                        tempMinute.value = time.minute
-                    },
-                    value = if (task is SportTask && activity!!.supportsDistanceMetrics) {
-                        time.format(DateTimeFormatter.ofPattern("HH:mm"))
-                    } else {
-                        "${time.format(DateTimeFormatter.ofPattern("HH:mm"))} - " +
-                                (time.plus(duration)).format(DateTimeFormatter.ofPattern("HH:mm"))
+                    onDurationChange = { newDuration ->
+                        duration = newDuration
                     }
                 )
-
-                EditableDateItem(
-                    label = "Date",
-                    value = date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd, EEEE")),
-                    onDateSelected = { selectedDate ->
-                        date = date
-                            .withYear(selectedDate.year)
-                            .withMonth(selectedDate.monthValue)
-                            .withDayOfMonth(selectedDate.dayOfMonth)
-                    }
-                )
-
+            } else {
                 EditableInfoItem(
                     dialogContent = {
                         Column {
-                            Text(
-                                text = "Reminder Time: ${editingReminderTime?.toMinutes() ?: 0} minutes",
-                                style = TextStyle(fontSize = 16.sp),
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(start = 4.dp)
-                            )
-
-                            Slider(
-                                value = editingReminderTime
+                            val initial = remember(tempDuration) {
+                                tempDuration
                                     ?.toMinutes()
-                                    ?.toFloat() ?: 0f,
-                                onValueChange = { newValue ->
-                                    editingReminderTime = Duration.ofMinutes(newValue.toLong())
-                                },
-                                valueRange = 1f..120f,
-                                steps = 120,
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(
-                                        start = 8.dp,
-                                        end = 8.dp,
-                                        bottom = 8.dp
-                                    )
+                                    ?.toFloat()
+                                    ?: 0f
+                            }
+
+                            Picker(
+                                items = (0..300 step 5).toList(),
+                                label = { "$it minutes" },
+                                onChange = { tempDuration = Duration.ofMinutes(it.toLong()) },
+                                startIndex = initial.toInt() / 5,
+                                state = rememberPickerState(initialValue = initial)
                             )
                         }
                     },
-                    dialogTitle = { Text("Editing reminder time") },
-                    label = "Reminder Time",
-                    onConfirm = { reminderTime = editingReminderTime },
-                    onDismiss = { editingReminderTime = reminderTime },
-                    value = if (reminderTime != null)
-                        "${reminderTime?.toMinutes()} ${
-                            if (reminderTime?.toMinutes()?.toInt() == 1) "minute" else "minutes"
-                        } before task" else ""
+                    dialogTitle = { Text("Editing duration") },
+                    label = "Duration",
+                    onConfirm = { duration = tempDuration },
+                    onDismiss = { tempDuration = duration },
+                    value = "${duration?.toMinutes()} minutes"
                 )
+            }
 
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(
-                            horizontal = 24.dp,
-                            vertical = 15.dp
-                        ),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    ButtonConfirm(
-                        border = BorderStroke(
-                            1.dp,
-                            Color.Red
-                        ),
-                        colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.Red),
-                        content = {
-                            Row(verticalAlignment = Alignment.CenterVertically) {
-                                Icon(
-                                    contentDescription = "Delete task icon",
-                                    imageVector = Icons.Outlined.Delete
-                                )
-
-                                Text(
-                                    style = MaterialTheme.typography.titleSmall,
-                                    text = "Delete"
-                                )
-                            }
-                        },
-                        confirmationButtonContent = { Text("Delete") },
-                        confirmationDescription = { Text("If the task is deleted, it cannot be recovered") },
-                        confirmationTitle = { Text("Are you sure you want to delete this task?") },
-                        onConfirm = {
-                            model.remove(task)
-
-                            onDialogClose()
-                        },
-                        shape = MaterialTheme.shapes.extraLarge
+            EditableInfoItem(
+                dialogContent = {
+                    PickerTime(
+                        selectedHour = tempHour,
+                        selectedMinute = tempMinute,
+                        onChange = { hour, minute ->
+                            tempHour.value = hour
+                            tempMinute.value = minute
+                        }
                     )
+                },
+                dialogTitle = { Text("Editing scheduled at") },
+                label = "Scheduled at",
+                onConfirm = {
+                    time = time
+                        .withHour(tempHour.value)
+                        .withMinute(tempMinute.value)
+                },
+                onDismiss = {
+                    tempHour.value = time.hour
+                    tempMinute.value = time.minute
+                },
+                value = if (task is SportTask && activity!!.supportsDistanceMetrics) {
+                    time.format(DateTimeFormatter.ofPattern("HH:mm"))
+                } else {
+                    "${time.format(DateTimeFormatter.ofPattern("HH:mm"))} - " +
+                            (time.plus(duration)).format(DateTimeFormatter.ofPattern("HH:mm"))
+                }
+            )
 
-                    Button(
-                        onClick = {
-                            model.update(
-                                { task ->
-                                    task.title = title
-                                    task.description = description
-                                    task.duration = duration
-                                    task.reminderTime = reminderTime
-                                    task.date = date
-                                    task.time = time
+            EditableDateItem(
+                label = "Date",
+                value = date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd, EEEE")),
+                onDateSelected = { selectedDate ->
+                    date = date
+                        .withYear(selectedDate.year)
+                        .withMonth(selectedDate.monthValue)
+                        .withDayOfMonth(selectedDate.dayOfMonth)
+                }
+            )
 
-                                    when (task) {
-                                        is SportTask -> {
-                                            task.activity = activity!!
-                                            task.distance = distance
-                                        }
+            EditableInfoItem(
+                dialogContent = {
+                    Column {
+                        val initial = remember(editingReminderTime) {
+                            editingReminderTime
+                                ?.toMinutes()
+                                ?.toFloat()
+                                ?: 0f
+                        }
 
-                                        is MealTask -> {
-                                            task.recipe = description ?: ""
-                                            task.description = ""
-                                        }
-                                    }
-                                },
-                                task
+                        Picker(
+                            items = (0..120 step 5).toList(),
+                            label = { "$it minutes" },
+                            onChange = { editingReminderTime = Duration.ofMinutes(it.toLong()) },
+                            startIndex = initial.toInt() / 5,
+                            state = rememberPickerState(initialValue = initial)
+                        )
+                    }
+                },
+                dialogTitle = { Text("Editing reminder time") },
+                label = "Reminder Time",
+                onConfirm = { reminderTime = editingReminderTime },
+                onDismiss = { editingReminderTime = reminderTime },
+                value = if (reminderTime != null)
+                    "${reminderTime?.toMinutes()} ${
+                        if (reminderTime
+                                ?.toMinutes()
+                                ?.toInt() == 1
+                        ) "minute" else "minutes"
+                    } before task" else ""
+            )
+
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        horizontal = 24.dp,
+                        vertical = 15.dp
+                    ),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                ButtonConfirm(
+                    border = BorderStroke(
+                        1.dp,
+                        Color.Red
+                    ),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.Red),
+                    content = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                contentDescription = "Delete task icon",
+                                imageVector = Icons.Outlined.Delete
                             )
 
-                            onDialogClose()
+                            Text(
+                                style = MaterialTheme.typography.titleSmall,
+                                text = "Delete"
+                            )
                         }
-                    ) {
-                        Text("Save")
+                    },
+                    confirmationButtonContent = { Text("Delete") },
+                    confirmationDescription = { Text("If the task is deleted, it cannot be recovered") },
+                    confirmationTitle = { Text("Are you sure you want to delete this task?") },
+                    onConfirm = {
+                        model.remove(task)
+
+                        onDialogClose()
+                    },
+                    shape = MaterialTheme.shapes.extraLarge
+                )
+
+                Button(
+                    onClick = {
+                        model.update(
+                            { task ->
+                                task.title = title
+                                task.description = description
+                                task.duration = duration
+                                task.reminderTime = reminderTime
+                                task.date = date
+                                task.time = time
+
+                                when (task) {
+                                    is SportTask -> {
+                                        task.activity = activity!!
+                                        task.distance = distance
+                                    }
+
+                                    is MealTask -> {
+                                        task.recipe = description ?: ""
+                                        task.description = ""
+                                    }
+                                }
+                            },
+                            task
+                        )
+
+                        onDialogClose()
                     }
+                ) {
+                    Text("Save")
                 }
             }
         }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskViewModel.kt
@@ -14,6 +14,7 @@ import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
 import com.pvp.app.model.User
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
@@ -65,7 +66,7 @@ class TaskViewModel @Inject constructor(
         time: LocalTime? = null,
         title: String
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             state
                 .first()
                 .let { state ->
@@ -98,7 +99,7 @@ class TaskViewModel @Inject constructor(
         time: LocalTime? = null,
         title: String
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             state
                 .first()
                 .let { state ->
@@ -131,7 +132,7 @@ class TaskViewModel @Inject constructor(
         time: LocalTime? = null,
         title: String
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             state
                 .first()
                 .let { state ->
@@ -213,7 +214,7 @@ class TaskViewModel @Inject constructor(
         handle: (T) -> Unit,
         task: T
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             task.cancelNotification()
 
             val (taskModified, updatePoints) = resolve(
@@ -237,7 +238,7 @@ class TaskViewModel @Inject constructor(
     }
 
     fun remove(task: Task) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             task.cancelNotification()
 
             taskService.remove(task)

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TasksOfDay.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TasksOfDay.kt
@@ -60,7 +60,7 @@ fun TasksOfDay(tasks: List<Task>) {
         contentAlignment = Alignment.Center
     ) {
         Column(modifier = Modifier.fillMaxWidth(0.9f)) {
-            var filter by remember { mutableStateOf(TaskFilter.General) }
+            var filter by remember { mutableStateOf(TaskFilter.Daily) }
 
             Spacer(modifier = Modifier.padding(16.dp))
 

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TasksOfDay.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TasksOfDay.kt
@@ -147,5 +147,5 @@ enum class TaskFilter(val displayName: String) {
     Daily("Daily"),
     General("General"),
     Meal("Meal"),
-    Sports("Sports")
+    Sports("Sport")
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationScreen.kt
@@ -101,9 +101,9 @@ fun DecorationScreen(modifier: Modifier) {
 
     Column(
         modifier = Modifier
+            .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .then(modifier)
-            .fillMaxSize()
             .background(MaterialTheme.colorScheme.background)
     ) {
         Spacer(modifier = Modifier.size(16.dp))

--- a/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -35,20 +36,28 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pvp.app.ui.common.Dialog
-import com.pvp.app.ui.screen.decoration.DecorationScreenState.Companion.ScreenStateHandler
+import com.pvp.app.ui.common.ProgressIndicatorWithinDialog
+import com.pvp.app.ui.common.showToast
+
+@Composable
+private fun screens() = listOf<Pair<String, @Composable () -> Unit>>(
+    "Store" to { Store() },
+    "Owned" to { Apply() },
+)
 
 @Composable
 private fun Apply(model: DecorationViewModel = hiltViewModel()) {
     val state by model.state.collectAsStateWithLifecycle()
     val holdersOwned by remember(state.holders) { mutableStateOf(state.holders.filter { it.owned }) }
 
-    ScreenStateHandler(
+    StateHandler(
         resetState = model::resetScreenState,
         state = state.state
     )
@@ -135,6 +144,64 @@ fun DecorationScreen(modifier: Modifier) {
 }
 
 @Composable
+private fun StateHandler(
+    resetState: () -> Unit,
+    state: DecorationScreenState
+) {
+    val context = LocalContext.current
+
+    if (state is DecorationScreenState.Loading) {
+        ProgressIndicatorWithinDialog()
+
+        return
+    }
+
+    when (state) {
+        is DecorationScreenState.Success -> {
+            LaunchedEffect(state) {
+                when (state) {
+                    is DecorationScreenState.Success.Apply -> context.showToast(
+                        message = "Successfully applied decoration"
+                    )
+
+                    is DecorationScreenState.Success.Purchase -> context.showToast(
+                        message = "Successfully purchased decoration"
+                    )
+
+                    is DecorationScreenState.Success.Unapply -> context.showToast(
+                        message = "Successfully removed decoration"
+                    )
+
+                    else -> context.showToast(message = "Success")
+                }
+
+                resetState()
+            }
+        }
+
+        is DecorationScreenState.Error -> {
+            LaunchedEffect(state) {
+                when (state) {
+                    is DecorationScreenState.Error.AlreadyOwned -> context.showToast(
+                        message = "You already own this decoration"
+                    )
+
+                    is DecorationScreenState.Error.InsufficientFunds -> context.showToast(
+                        message = "Not enough points to purchase decoration"
+                    )
+
+                    else -> context.showToast(message = "Error has occurred")
+                }
+
+                resetState()
+            }
+        }
+
+        else -> {}
+    }
+}
+
+@Composable
 private fun Store(model: DecorationViewModel = hiltViewModel()) {
     var item by remember { mutableStateOf<DecorationHolder?>(null) }
     var showDialog by remember { mutableStateOf(false) }
@@ -144,7 +211,7 @@ private fun Store(model: DecorationViewModel = hiltViewModel()) {
         mutableStateOf(state.holders.filter { it.owned || it.decoration.price < 0 })
     }
 
-    ScreenStateHandler(
+    StateHandler(
         resetState = model::resetScreenState,
         state = state.state
     )
@@ -241,9 +308,3 @@ private fun Store(model: DecorationViewModel = hiltViewModel()) {
         title = { Text("Confirm purchase") }
     )
 }
-
-@Composable
-private fun screens() = listOf<Pair<String, @Composable () -> Unit>>(
-    "Store" to { Store() },
-    "Owned" to { Apply() },
-)

--- a/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationViewModel.kt
@@ -67,6 +67,11 @@ class DecorationViewModel @Inject constructor(
                         it.copy(
                             avatar = state.avatar,
                             holders = state.holders,
+                            state = if (it.state == DecorationScreenState.Loading) {
+                                DecorationScreenState.NoOperation
+                            } else {
+                                it.state
+                            },
                             user = state.user
                         )
                     }

--- a/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/decoration/DecorationViewModel.kt
@@ -80,7 +80,7 @@ class DecorationViewModel @Inject constructor(
     }
 
     fun apply(decoration: Decoration) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             val state = _state.first()
 
             _state.update { it.copy(state = DecorationScreenState.Loading) }
@@ -107,7 +107,7 @@ class DecorationViewModel @Inject constructor(
     fun purchase(decoration: Decoration) {
         _state.update { it.copy(state = DecorationScreenState.Loading) }
 
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             val state = _state.first()
             val holder = state.holders.first { it.decoration == decoration }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/decoration/Models.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/decoration/Models.kt
@@ -1,12 +1,8 @@
 package com.pvp.app.ui.screen.decoration
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.graphics.ImageBitmap
-import androidx.compose.ui.platform.LocalContext
 import com.pvp.app.model.Decoration
 import com.pvp.app.model.User
-import com.pvp.app.ui.common.showToast
 
 data class DecorationHolder(
     val applied: Boolean = false,
@@ -20,7 +16,7 @@ data class DecorationState(
         1
     ),
     val holders: List<DecorationHolder> = emptyList(),
-    val state: DecorationScreenState = DecorationScreenState.NoOperation,
+    val state: DecorationScreenState = DecorationScreenState.Loading,
     val user: User = User()
 )
 
@@ -48,42 +44,5 @@ sealed class DecorationScreenState {
         data object Unapply : Success()
 
         companion object : Success()
-    }
-
-    companion object {
-
-        @Composable
-        fun ScreenStateHandler(
-            resetState: () -> Unit,
-            state: DecorationScreenState
-        ) {
-            val context = LocalContext.current
-
-            LaunchedEffect(state) {
-                when (state) {
-                    is NoOperation -> return@LaunchedEffect
-
-                    is Success -> when (state) {
-                        is Success.Apply -> context.showToast(message = "Successfully applied decoration")
-                        is Success.Purchase -> context.showToast(message = "Successfully purchased decoration")
-                        is Success.Unapply -> context.showToast(message = "Successfully removed decoration")
-
-                        else -> context.showToast(message = "Success")
-                    }
-
-                    is Error -> when (state) {
-                        is Error.AlreadyOwned -> context.showToast(message = "You already own this decoration")
-                        is Error.InsufficientFunds -> context.showToast(message = "Not enough points to purchase decoration")
-
-                        else -> context.showToast(message = "Error has occurred")
-
-                    }
-
-                    else -> {}
-                }
-
-                resetState()
-            }
-        }
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/drawer/DrawerScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/drawer/DrawerScreen.kt
@@ -15,27 +15,27 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalDrawerSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.pvp.app.R
 import com.pvp.app.ui.common.ButtonConfirm
+import com.pvp.app.ui.common.RouteUtil.RouteTitle
 import com.pvp.app.ui.common.showToast
 import com.pvp.app.ui.router.Route
 
 @Composable
-private fun DrawerBody(
+private fun Body(
     modifier: Modifier = Modifier,
     onClick: Route.() -> Unit,
     routes: List<Route>,
@@ -43,8 +43,9 @@ private fun DrawerBody(
 ) {
     LazyColumn(modifier = modifier) {
         items(routes) {
-            DrawerBodyRow(
+            BodyRow(
                 modifier = Modifier
+                    .fillMaxWidth()
                     .height(48.dp)
                     .background(
                         color = if (route.path == it.path) {
@@ -57,9 +58,7 @@ private fun DrawerBody(
                     .padding(8.dp)
                     .clickable(
                         enabled = route.path != it.path,
-                        onClick = { onClick.invoke(it) },
-                        onClickLabel = "Navigate to ${stringResource(it.resourceTitleId)}",
-                        role = Role.Button
+                        onClick = { onClick.invoke(it) }
                     ),
                 route = it
             )
@@ -68,33 +67,38 @@ private fun DrawerBody(
 }
 
 @Composable
-private fun DrawerBodyRow(
+private fun BodyRow(
     modifier: Modifier = Modifier,
     route: Route
 ) {
+    val options = remember(route) {
+        when (route) {
+            is Route.Node -> {
+                route.options
+            }
+
+            is Route.Root -> {
+                route.start.options
+            }
+        }
+    }
+
     Row(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        route.icon?.let {
-            Icon(
-                contentDescription = route.iconDescription,
-                imageVector = it
-            )
+        if (options.icon != null) {
+            options.icon.invoke()
 
             Spacer(modifier = Modifier.width(16.dp))
         }
 
-        Text(
-            modifier = Modifier.weight(1f),
-            style = MaterialTheme.typography.titleLarge,
-            text = stringResource(id = route.resourceTitleId)
-        )
+        (options.title ?: { RouteTitle(title = "Title not defined") })()
     }
 }
 
 @Composable
-private fun DrawerFooter(
+private fun Footer(
     modifier: Modifier = Modifier,
     onSignOut: () -> Unit
 ) {
@@ -119,9 +123,7 @@ private fun DrawerFooter(
 }
 
 @Composable
-private fun DrawerHeader(
-    modifier: Modifier = Modifier
-) {
+private fun Header(modifier: Modifier = Modifier) {
     Row(
         horizontalArrangement = Arrangement.Start,
         modifier = modifier,
@@ -154,19 +156,19 @@ fun DrawerScreen(
         ) {
             val textSignOut = stringResource(R.string.screen_profile_toast_error)
 
-            DrawerHeader(
+            Header(
                 Modifier
                     .fillMaxWidth()
                     .weight(0.1f)
             )
 
-            Spacer(modifier = Modifier.size(4.dp))
+            Spacer(modifier = Modifier.size(8.dp))
 
             HorizontalDivider()
 
-            Spacer(modifier = Modifier.size(4.dp))
+            Spacer(modifier = Modifier.size(16.dp))
 
-            DrawerBody(
+            Body(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(0.8f),
@@ -177,7 +179,7 @@ fun DrawerScreen(
 
             val context = LocalContext.current
 
-            DrawerFooter(
+            Footer(
                 modifier = Modifier
                     .fillMaxWidth()
                     .weight(0.1f),

--- a/app/src/main/java/com/pvp/app/ui/screen/drawer/DrawerScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/drawer/DrawerScreen.kt
@@ -55,11 +55,11 @@ private fun Body(
                         },
                         shape = MaterialTheme.shapes.extraSmall
                     )
-                    .padding(8.dp)
                     .clickable(
                         enabled = route.path != it.path,
                         onClick = { onClick.invoke(it) }
-                    ),
+                    )
+                    .padding(8.dp),
                 route = it
             )
         }

--- a/app/src/main/java/com/pvp/app/ui/screen/drawer/DrawerScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/drawer/DrawerScreen.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.pvp.app.R
 import com.pvp.app.ui.common.ButtonConfirm
-import com.pvp.app.ui.common.RouteUtil.RouteTitle
+import com.pvp.app.ui.common.RouteTitle
 import com.pvp.app.ui.common.showToast
 import com.pvp.app.ui.router.Route
 

--- a/app/src/main/java/com/pvp/app/ui/screen/drawer/DrawerViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/drawer/DrawerViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.pvp.app.api.AuthenticationService
 import com.pvp.app.model.SignOutResult
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -16,7 +17,7 @@ class DrawerViewModel @Inject constructor(
     fun signOut(
         onSignOut: (SignOutResult) -> Unit
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             authenticationService.signOut(onSignOut)
         }
     }

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
@@ -1,0 +1,354 @@
+package com.pvp.app.ui.screen.friends
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.outlined.FactCheck
+import androidx.compose.material.icons.outlined.DoNotStep
+import androidx.compose.material.icons.outlined.LocalFireDepartment
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pvp.app.model.Friends
+import com.pvp.app.ui.common.ButtonConfirm
+import com.pvp.app.ui.common.Experience
+import com.pvp.app.ui.common.ProgressIndicator
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun FriendScreen(
+    model: FriendsViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier
+) {
+    val state by model.stateFriend.collectAsStateWithLifecycle()
+
+    if (state.loading) {
+        ProgressIndicator()
+
+        return
+    }
+
+    val details = state.details
+    val entry = state.entry
+    val friends = state.friendsMutual
+    val tasks = state.tasksCompleted
+    val stateScroll = rememberScrollState()
+
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(stateScroll)
+            .then(modifier)
+            .padding(8.dp)
+            .clip(MaterialTheme.shapes.small)
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .padding(8.dp)
+    ) {
+        Header(entry = entry)
+
+        Spacer(modifier = Modifier.size(8.dp))
+
+        Content(
+            details = details,
+            friends = friends,
+            tasks = tasks
+        )
+
+        Spacer(modifier = Modifier.size(8.dp))
+
+        Remove { model.remove(entry.user.email) }
+    }
+}
+
+@Composable
+private fun Header(entry: FriendEntry) {
+    AvatarBox(entry)
+
+    Text(
+        style = MaterialTheme.typography.titleSmall,
+        text = entry.user.username
+    )
+
+    Spacer(modifier = Modifier.height(6.dp))
+
+    Experience(
+        experience = entry.user.experience,
+        experienceRequired = (entry.user.level + 1) * (entry.user.level + 1) * 13,
+        level = entry.user.level,
+        paddingStart = 0.dp,
+        paddingEnd = 0.dp,
+        fontSize = 14,
+        fontWeight = FontWeight.Normal,
+        height = 26.dp,
+        textStyle = MaterialTheme.typography.titleSmall,
+        progressTextStyle = MaterialTheme.typography.bodySmall
+    )
+
+    Spacer(modifier = Modifier.height(6.dp))
+}
+
+@Composable
+private fun Remove(onRemove: () -> Unit) {
+    Row(
+        horizontalArrangement = Arrangement.End,
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        ButtonConfirm(
+            confirmationDescription = { Text("If friend is removed, you will have to request for friendship again") },
+            confirmationTitle = { Text("Are you sure you want to remove this friend?") },
+            colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.Red),
+            content = { Text("Remove Friend") },
+            modifier = Modifier
+                .height(38.dp)
+                .border(
+                    1.dp,
+                    Color.Red,
+                    MaterialTheme.shapes.extraLarge
+                ),
+            onConfirm = onRemove,
+            shape = MaterialTheme.shapes.extraLarge
+        )
+    }
+}
+
+@Composable
+fun Content(
+    details: Friends,
+    friends: List<FriendEntry>,
+    tasks: Int
+) {
+    val sinceDateTime = LocalDateTime.ofInstant(
+        Instant.ofEpochMilli(details.since),
+        ZoneId.systemDefault()
+    )
+
+    val formattedDate = sinceDateTime.format(
+        DateTimeFormatter.ofPattern(
+            "yyyy/MM/dd"
+        )
+    )
+
+    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+        ActivityInfo(tasks)
+
+        FriendInfo(
+            formattedDate,
+            friends
+        )
+    }
+}
+
+@Composable
+private fun AvatarBox(friend: FriendEntry) {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .size(100.dp)
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.primaryContainer)
+    ) {
+        Image(
+            bitmap = friend.avatar,
+            contentDescription = "Friend avatar",
+            modifier = Modifier
+                .size(96.dp)
+                .clip(CircleShape)
+        )
+    }
+}
+
+@Composable
+private fun ActivityInfo(tasksCompleted: Int) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        InfoHeader(text = "7 days activity")
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .height(90.dp)
+                .clip(MaterialTheme.shapes.small)
+                .background(MaterialTheme.colorScheme.surface)
+                .padding(vertical = 4.dp),
+            verticalArrangement = Arrangement.SpaceEvenly
+        ) {
+            ActivityRow(
+                icon = Icons.Outlined.DoNotStep,
+                contentDescription = "steps",
+                text = "63819 steps made"
+            )
+
+            HorizontalDivider(
+                color = Color.Gray,
+                thickness = 1.dp,
+                modifier = Modifier.padding(horizontal = 14.dp)
+            )
+
+            ActivityRow(
+                icon = Icons.Outlined.LocalFireDepartment,
+                contentDescription = "calories",
+                text = "6571 calories burned"
+            )
+
+            HorizontalDivider(
+                color = Color.Gray,
+                thickness = 1.dp,
+                modifier = Modifier.padding(horizontal = 14.dp)
+            )
+
+            ActivityRow(
+                icon = Icons.AutoMirrored.Outlined.FactCheck,
+                contentDescription = "tasks",
+                text = "$tasksCompleted sport tasks completed"
+            )
+        }
+
+        Spacer(modifier = Modifier.height(6.dp))
+    }
+}
+
+@Composable
+private fun ActivityRow(
+    contentDescription: String,
+    icon: ImageVector,
+    text: String
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Icon(
+            contentDescription = contentDescription,
+            imageVector = icon,
+            modifier = Modifier.size(20.dp)
+        )
+
+        Text(
+            modifier = Modifier.padding(start = 8.dp),
+            style = MaterialTheme.typography.titleSmall,
+            text = text
+        )
+    }
+}
+
+@Composable
+private fun FriendInfo(
+    formattedDate: String,
+    mutualFriends: List<FriendEntry>
+) {
+    InfoHeader(text = "Other information")
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .clip(MaterialTheme.shapes.small)
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(
+                horizontal = 14.dp,
+                vertical = 4.dp
+            )
+    ) {
+        Text(
+            style = MaterialTheme.typography.titleSmall,
+            text = "Friends since - $formattedDate"
+        )
+
+        Spacer(modifier = Modifier.height(4.dp))
+
+        if (mutualFriends.isEmpty()) {
+            Text(
+                style = MaterialTheme.typography.titleSmall,
+                text = "No mutual friends"
+            )
+        } else {
+            Text(
+                style = MaterialTheme.typography.titleSmall,
+                text = "Mutual friends"
+            )
+
+            Spacer(modifier = Modifier.height(4.dp))
+
+            for (mutualFriend in mutualFriends) {
+                Row(
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    Text(
+                        style = MaterialTheme.typography.titleSmall,
+                        text = mutualFriend.user.username
+                    )
+
+                    Box(
+                        contentAlignment = Alignment.Center,
+                        modifier = Modifier
+                            .size(20.dp)
+                            .clip(CircleShape)
+                            .background(MaterialTheme.colorScheme.primaryContainer)
+                    ) {
+                        Image(
+                            bitmap = mutualFriend.avatar,
+                            contentDescription = "Friend avatar",
+                            modifier = Modifier
+                                .size(18.dp)
+                                .clip(CircleShape)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun InfoHeader(text: String) {
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(
+                color = MaterialTheme.colorScheme.surface,
+                shape = MaterialTheme.shapes.small
+            )
+            .padding(vertical = 4.dp)
+    ) {
+        Text(
+            style = MaterialTheme.typography.titleSmall,
+            text = text
+        )
+    }
+
+    Spacer(modifier = Modifier.height(3.dp))
+}

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
@@ -46,6 +46,7 @@ import com.pvp.app.R
 import com.pvp.app.model.Friends
 import com.pvp.app.ui.common.ButtonConfirm
 import com.pvp.app.ui.common.Experience
+import com.pvp.app.ui.common.LocalHorizontalPagerSettled
 import com.pvp.app.ui.common.LocalRouteOptionsApplier
 import com.pvp.app.ui.common.ProgressIndicatorWithinDialog
 import com.pvp.app.ui.common.RouteUtil.RouteTitle
@@ -386,7 +387,8 @@ private fun RouteOptionsApplier(
     controller: NavHostController,
     username: String
 ) {
-    var applierRequired by remember { mutableStateOf(false) }
+    val settled = LocalHorizontalPagerSettled.current
+    var applierRequired by remember(settled) { mutableStateOf(settled) }
 
     if (applierRequired) {
         LocalRouteOptionsApplier.current {

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
@@ -49,7 +49,7 @@ import com.pvp.app.ui.common.Experience
 import com.pvp.app.ui.common.LocalHorizontalPagerSettled
 import com.pvp.app.ui.common.LocalRouteOptionsApplier
 import com.pvp.app.ui.common.ProgressIndicatorWithinDialog
-import com.pvp.app.ui.common.RouteUtil.RouteTitle
+import com.pvp.app.ui.common.RouteTitle
 import com.pvp.app.ui.router.Route
 import com.pvp.app.ui.router.Routes
 import java.time.Instant

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
@@ -41,7 +41,7 @@ import androidx.navigation.NavHostController
 import com.pvp.app.model.Friends
 import com.pvp.app.ui.common.ButtonConfirm
 import com.pvp.app.ui.common.Experience
-import com.pvp.app.ui.common.ProgressIndicator
+import com.pvp.app.ui.common.ProgressIndicatorWithinDialog
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.ZoneId
@@ -56,12 +56,9 @@ fun FriendScreen(
 ) {
     val state by model.stateFriend.collectAsStateWithLifecycle()
 
-    if (state.loading) {
-        ProgressIndicator()
+    HandleState(state = state.state)
 
-        return
-    }
-
+    // TODO: Remove this when the issue is fixed
     LaunchedEffect(state.entry.user.username) {
         resolveOptions()
     }
@@ -365,4 +362,13 @@ private fun InfoHeader(text: String) {
     }
 
     Spacer(modifier = Modifier.height(3.dp))
+}
+
+@Composable
+fun HandleState(state: FriendScreenState) {
+    when (state) {
+        FriendScreenState.Loading -> ProgressIndicatorWithinDialog()
+
+        else -> {}
+    }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
@@ -107,8 +107,10 @@ fun FriendScreen(
 private fun Header(entry: FriendEntry) {
     AvatarBox(entry)
 
+    Spacer(modifier = Modifier.height(8.dp))
+
     Text(
-        style = MaterialTheme.typography.titleSmall,
+        style = MaterialTheme.typography.titleMedium,
         text = entry.user.username
     )
 
@@ -187,7 +189,7 @@ private fun AvatarBox(friend: FriendEntry) {
     Box(
         contentAlignment = Alignment.Center,
         modifier = Modifier
-            .size(100.dp)
+            .size(150.dp)
             .clip(CircleShape)
             .background(MaterialTheme.colorScheme.primaryContainer)
     ) {
@@ -195,7 +197,7 @@ private fun AvatarBox(friend: FriendEntry) {
             bitmap = friend.avatar,
             contentDescription = "Friend avatar",
             modifier = Modifier
-                .size(96.dp)
+                .size(150.dp)
                 .clip(CircleShape)
         )
     }

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +37,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavHostController
 import com.pvp.app.model.Friends
 import com.pvp.app.ui.common.ButtonConfirm
 import com.pvp.app.ui.common.Experience
@@ -47,8 +49,10 @@ import java.time.format.DateTimeFormatter
 
 @Composable
 fun FriendScreen(
+    controller: NavHostController,
     model: FriendsViewModel = hiltViewModel(),
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    resolveOptions: () -> Unit
 ) {
     val state by model.stateFriend.collectAsStateWithLifecycle()
 
@@ -56,6 +60,10 @@ fun FriendScreen(
         ProgressIndicator()
 
         return
+    }
+
+    LaunchedEffect(state.entry.user.username) {
+        resolveOptions()
     }
 
     val details = state.details
@@ -87,7 +95,11 @@ fun FriendScreen(
 
         Spacer(modifier = Modifier.size(8.dp))
 
-        Remove { model.remove(entry.user.email) }
+        Remove {
+            model.remove(entry.user.email)
+
+            controller.popBackStack()
+        }
     }
 }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendsScreen.kt
@@ -1,7 +1,6 @@
 package com.pvp.app.ui.screen.friends
 
 import android.widget.Toast
-import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.RowScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -23,24 +21,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.outlined.FactCheck
 import androidx.compose.material.icons.outlined.CheckCircle
 import androidx.compose.material.icons.outlined.DoNotDisturbOn
-import androidx.compose.material.icons.outlined.DoNotStep
 import androidx.compose.material.icons.outlined.EmojiEvents
 import androidx.compose.material.icons.outlined.FilterAlt
 import androidx.compose.material.icons.outlined.GroupAdd
-import androidx.compose.material.icons.outlined.LocalFireDepartment
 import androidx.compose.material.icons.outlined.WorkspacePremium
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Badge
 import androidx.compose.material3.BadgedBox
-import androidx.compose.material3.ButtonColors
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Tab
@@ -48,18 +38,14 @@ import androidx.compose.material3.TabRow
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
@@ -67,15 +53,9 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import com.pvp.app.model.FriendObject
-import com.pvp.app.ui.common.Button
-import com.pvp.app.ui.common.ButtonConfirm
+import androidx.navigation.NavController
 import com.pvp.app.ui.common.ButtonWithDialog
-import com.pvp.app.ui.common.Experience
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
+import com.pvp.app.ui.common.ProgressIndicator
 
 private enum class SortingType {
     EXPERIENCE,
@@ -84,21 +64,41 @@ private enum class SortingType {
 
 @Composable
 fun FriendsScreen(
+    controller: NavController,
     model: FriendsViewModel = hiltViewModel(),
     modifier: Modifier
 ) {
-    val context = LocalContext.current
-    val toastMessage by model.toastMessage
-    val friendObject by model.userFriendObject.collectAsStateWithLifecycle()
-    val friendEmail = remember { mutableStateOf("") }
-    val sortingType = remember { mutableStateOf(SortingType.EXPERIENCE) }
-    val friends by model.userFriends.collectAsState()
-    val friendsSorted = remember { mutableStateOf(friends) }
-    val scrollState = rememberScrollState()
-    val tempSortingType = remember { mutableStateOf(sortingType.value) }
+    val state by model.stateFriends.collectAsStateWithLifecycle()
 
-    LaunchedEffect(toastMessage) {
-        toastMessage?.let {
+    if (state.loading) {
+        ProgressIndicator()
+
+        return
+    }
+
+    val context = LocalContext.current
+    val friendEmail = remember { mutableStateOf("") }
+    val friendObject = state.friendObject
+    val friends = state.friends
+    val message by model.toastMessage
+    val scrollState = rememberScrollState()
+    val sortingType = remember { mutableStateOf(SortingType.EXPERIENCE) }
+    val sortingTypeTemp = remember { mutableStateOf(sortingType.value) }
+
+    val friendsSorted = remember(
+        friends,
+        sortingType
+    ) {
+        mutableStateOf(
+            when (sortingType.value) {
+                SortingType.EXPERIENCE -> friends.sortedByDescending { it.user.experience }
+                SortingType.POINTS -> friends.sortedByDescending { it.user.points }
+            }
+        )
+    }
+
+    LaunchedEffect(message) {
+        message?.let {
             Toast
                 .makeText(
                     context,
@@ -111,35 +111,17 @@ fun FriendsScreen(
         }
     }
 
-    LaunchedEffect(
-        sortingType.value,
-        friends
-    ) {
-        friendsSorted.value = when (sortingType.value) {
-            SortingType.EXPERIENCE -> friends.sortedByDescending { it.user.experience }
-            SortingType.POINTS -> friends.sortedByDescending { it.user.points }
-        }
-    }
-
     Column(
         modifier = modifier
             .fillMaxSize()
-            .padding(
-                start = 16.dp,
-                end = 16.dp,
-                bottom = 16.dp
-            )
+            .padding(8.dp)
             .clip(MaterialTheme.shapes.small)
             .background(MaterialTheme.colorScheme.surfaceContainer)
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(
-                    start = 16.dp,
-                    end = 16.dp,
-                    top = 4.dp
-                ),
+                .padding(8.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -166,7 +148,7 @@ fun FriendsScreen(
                 },
                 confirmButtonContent = { Text("Add") },
                 onConfirm = {
-                    model.addFriend(friendEmail.value.trim())
+                    model.add(friendEmail.value.trim())
 
                     friendEmail.value = ""
                 },
@@ -243,8 +225,8 @@ fun FriendsScreen(
                                     RequestList(
                                         requests = friendObject.receivedRequests,
                                         requestTitle = "received",
-                                        acceptAction = { request -> model.acceptFriendRequest(request) },
-                                        denyAction = { request -> model.denyFriendRequest(request) }
+                                        acceptAction = { request -> model.accept(request) },
+                                        denyAction = { request -> model.deny(request) }
                                     )
                                 }
 
@@ -253,7 +235,7 @@ fun FriendsScreen(
                                         requests = friendObject.sentRequests,
                                         requestTitle = "sent",
                                         acceptAction = { },
-                                        denyAction = { request -> model.cancelSentRequest(request) }
+                                        denyAction = { request -> model.cancel(request) }
                                     )
                                 }
                             }
@@ -287,14 +269,14 @@ fun FriendsScreen(
                                     verticalAlignment = Alignment.CenterVertically,
                                     modifier = Modifier.clickable(
                                         onClick = {
-                                            tempSortingType.value = type
+                                            sortingTypeTemp.value = type
                                         }
                                     )
                                 ) {
                                     RadioButton(
-                                        selected = tempSortingType.value == type,
+                                        selected = sortingTypeTemp.value == type,
                                         onClick = {
-                                            tempSortingType.value = type
+                                            sortingTypeTemp.value = type
                                         }
                                     )
 
@@ -310,8 +292,8 @@ fun FriendsScreen(
                             }
                     }
                 },
-                onConfirm = { sortingType.value = tempSortingType.value },
-                onDismiss = { tempSortingType.value = sortingType.value },
+                onConfirm = { sortingType.value = sortingTypeTemp.value },
+                onDismiss = { sortingTypeTemp.value = sortingType.value },
                 shape = MaterialTheme.shapes.small
             )
         }
@@ -327,8 +309,11 @@ fun FriendsScreen(
 
         FriendList(
             friends = friendsSorted.value,
-            friendObject = friendObject,
-            model = model,
+            onSelect = { friend ->
+                model.select(friend.user.email)
+
+                controller.navigate("friend")
+            },
             scrollState = scrollState
         )
     }
@@ -337,8 +322,7 @@ fun FriendsScreen(
 @Composable
 private fun FriendList(
     friends: List<FriendEntry>,
-    friendObject: FriendObject,
-    model: FriendsViewModel,
+    onSelect: (FriendEntry) -> Unit,
     scrollState: ScrollState
 ) {
     Column(
@@ -348,10 +332,11 @@ private fun FriendList(
             .padding(bottom = 10.dp)
     ) {
         for ((index, friend) in friends.withIndex()) {
-            CustomButtonWithDialog(
+            Row(
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(40.dp)
+                    .clickable { onSelect(friend) }
                     .padding(
                         horizontal = 16.dp,
                         vertical = 2.dp
@@ -360,27 +345,13 @@ private fun FriendList(
                         MaterialTheme.colorScheme.secondaryContainer,
                         MaterialTheme.shapes.small
                     ),
-                content = {
-                    ListItemContent(
-                        index,
-                        friend
-                    )
-                },
-                contentPadding = PaddingValues(2.dp),
-                dialogTitle = { Text("${friend.user.username} information") },
-                dialogContent = {
-                    DialogContent(
-                        friend,
-                        friendObject,
-                        model
-                    )
-                },
-                confirmButtonContent = { Text("Remove") },
-                shape = MaterialTheme.shapes.small,
-                confirmationTitle = { Text("Are you sure you want to remove this friend?") },
-                confirmationOnConfirm = { model.removeFriend(friend.user.email) },
-                confirmationDescription = { Text("If friend is removed, you will have to request for friendship again") }
-            )
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                ListItemContent(
+                    index,
+                    friend
+                )
+            }
         }
     }
 }
@@ -428,7 +399,7 @@ private fun ListItemContent(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Text(
-            text = friend.user.username,
+            text = friend.user.email,
             style = MaterialTheme.typography.titleMedium,
             modifier = Modifier.padding(start = 4.dp)
         )
@@ -451,252 +422,6 @@ private fun ListItemContent(
     }
 
     Spacer(modifier = Modifier.width(6.dp))
-}
-
-@Composable
-private fun DialogContent(
-    friend: FriendEntry,
-    friendObject: FriendObject,
-    model: FriendsViewModel
-) {
-    val tasksCompleted by model.tasksCompleted.collectAsState()
-    val mutualFriends by model.mutualFriends.collectAsState()
-    val friendInfo = friendObject.friends.find { it.email == friend.user.email }
-
-    if (friendInfo != null) {
-        val sinceDateTime = LocalDateTime.ofInstant(
-            Instant.ofEpochMilli(friendInfo.since),
-            ZoneId.systemDefault()
-        )
-
-        val formattedDate = sinceDateTime.format(
-            DateTimeFormatter.ofPattern(
-                "yyyy/MM/dd"
-            )
-        )
-
-        model.tasksCompleted(friend.user.email)
-
-        model.getMutualFriends(friend.user.email)
-
-        Column(
-            modifier = Modifier
-                .padding(2.dp)
-                .fillMaxWidth()
-                .height(300.dp)
-                .verticalScroll(rememberScrollState()),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            AvatarBox(friend)
-
-            Spacer(modifier = Modifier.height(6.dp))
-
-            Experience(
-                experience = friend.user.experience,
-                experienceRequired = (friend.user.level + 1) * (friend.user.level + 1) * 13,
-                level = friend.user.level,
-                paddingStart = 0.dp,
-                paddingEnd = 0.dp,
-                fontSize = 14,
-                fontWeight = FontWeight.Normal,
-                height = 26.dp,
-                textStyle = MaterialTheme.typography.titleSmall,
-                progressTextStyle = MaterialTheme.typography.bodySmall
-            )
-
-            Spacer(modifier = Modifier.height(6.dp))
-
-            ActivityInfo(tasksCompleted)
-
-            FriendInfo(
-                formattedDate,
-                mutualFriends
-            )
-        }
-    }
-}
-
-@Composable
-private fun AvatarBox(friend: FriendEntry) {
-    Box(
-        contentAlignment = Alignment.Center,
-        modifier = Modifier
-            .size(100.dp)
-            .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.primaryContainer)
-    ) {
-        Image(
-            bitmap = friend.avatar,
-            contentDescription = "Friend avatar",
-            modifier = Modifier
-                .size(96.dp)
-                .clip(CircleShape)
-        )
-    }
-}
-
-@Composable
-private fun ActivityInfo(tasksCompleted: Int) {
-    Column(modifier = Modifier.fillMaxSize()) {
-        InfoHeader(text = "7 days activity")
-
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .height(90.dp)
-                .clip(MaterialTheme.shapes.small)
-                .background(MaterialTheme.colorScheme.surface)
-                .padding(vertical = 4.dp),
-            verticalArrangement = Arrangement.SpaceEvenly
-        ) {
-            ActivityRow(
-                icon = Icons.Outlined.DoNotStep,
-                contentDescription = "steps",
-                text = "63819 steps made"
-            )
-
-            HorizontalDivider(
-                color = Color.Gray,
-                thickness = 1.dp,
-                modifier = Modifier.padding(horizontal = 14.dp)
-            )
-
-            ActivityRow(
-                icon = Icons.Outlined.LocalFireDepartment,
-                contentDescription = "calories",
-                text = "6571 calories burned"
-            )
-
-            HorizontalDivider(
-                color = Color.Gray,
-                thickness = 1.dp,
-                modifier = Modifier.padding(horizontal = 14.dp)
-            )
-
-            ActivityRow(
-                icon = Icons.AutoMirrored.Outlined.FactCheck,
-                contentDescription = "tasks",
-                text = "$tasksCompleted tasks completed"
-            )
-        }
-
-        Spacer(modifier = Modifier.height(6.dp))
-    }
-}
-
-@Composable
-private fun ActivityRow(
-    icon: ImageVector,
-    contentDescription: String,
-    text: String
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(start = 16.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = contentDescription,
-            modifier = Modifier.size(20.dp)
-        )
-
-        Text(
-            text = text,
-            style = MaterialTheme.typography.titleSmall,
-            modifier = Modifier.padding(start = 8.dp)
-        )
-    }
-}
-
-@Composable
-private fun FriendInfo(
-    formattedDate: String,
-    mutualFriends: List<FriendEntry>
-) {
-    InfoHeader(text = "Friend information")
-
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .clip(MaterialTheme.shapes.small)
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(
-                vertical = 4.dp,
-                horizontal = 14.dp
-            )
-    ) {
-        Text(
-            text = "Friends since - $formattedDate",
-            style = MaterialTheme.typography.titleSmall
-        )
-
-        Spacer(modifier = Modifier.height(4.dp))
-
-        if (mutualFriends.isEmpty()) {
-            Text(
-                text = "No mutual friends",
-                style = MaterialTheme.typography.titleSmall
-            )
-        } else {
-            Text(
-                text = "Mutual friends",
-                style = MaterialTheme.typography.titleSmall
-            )
-
-            Spacer(modifier = Modifier.height(4.dp))
-
-            for (mutualFriend in mutualFriends) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceBetween
-                ) {
-                    Text(
-                        text = mutualFriend.user.username,
-                        style = MaterialTheme.typography.titleSmall,
-                    )
-
-                    Box(
-                        contentAlignment = Alignment.Center,
-                        modifier = Modifier
-                            .size(20.dp)
-                            .clip(CircleShape)
-                            .background(MaterialTheme.colorScheme.primaryContainer)
-                    ) {
-                        Image(
-                            bitmap = mutualFriend.avatar,
-                            contentDescription = "Friend avatar",
-                            modifier = Modifier
-                                .size(18.dp)
-                                .clip(CircleShape)
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun InfoHeader(text: String) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(
-                color = MaterialTheme.colorScheme.surface,
-                shape = MaterialTheme.shapes.small
-            )
-            .padding(vertical = 4.dp),
-        horizontalArrangement = Arrangement.Center
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.titleSmall
-        )
-    }
-
-    Spacer(modifier = Modifier.height(3.dp))
 }
 
 @Composable
@@ -764,107 +489,4 @@ private fun RequestList(
             }
         }
     }
-}
-
-@Composable
-private fun CustomButtonWithDialog(
-    modifier: Modifier = Modifier,
-    border: BorderStroke? = null,
-    colors: ButtonColors = ButtonDefaults.buttonColors(),
-    content: @Composable RowScope.() -> Unit = { Text("Open Dialog") },
-    contentAlignment: Alignment = Alignment.TopStart,
-    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
-    confirmButtonContent: @Composable RowScope.() -> Unit = { Text("Confirm") },
-    dismissButtonContent: @Composable RowScope.() -> Unit = { Text("Dismiss") },
-    dialogTitle: @Composable () -> Unit = { Text("Dialog Title") },
-    dialogContent: @Composable () -> Unit = { Text("Dialog Content") },
-    onDismiss: () -> Unit = {},
-    shape: Shape = MaterialTheme.shapes.extraSmall,
-    confirmationTitle: @Composable () -> Unit = { Text("Confirm to proceed") },
-    confirmationDescription: @Composable () -> Unit = { },
-    confirmationOnConfirm: () -> Unit
-) {
-    var showDialog by remember { mutableStateOf(false) }
-
-    Box(
-        contentAlignment = contentAlignment,
-        modifier = modifier
-    ) {
-        Button(
-            border = border,
-            colors = colors,
-            content = content,
-            contentPadding = contentPadding,
-            onClick = { showDialog = true },
-            shape = shape
-        )
-    }
-
-    CustomDialog(
-        buttonContentConfirm = confirmButtonContent,
-        buttonContentDismiss = dismissButtonContent,
-        content = dialogContent,
-        onDismiss = {
-            onDismiss()
-
-            showDialog = false
-        },
-        show = showDialog,
-        title = dialogTitle,
-        confirmationDescription = confirmationDescription,
-        confirmationTitle = confirmationTitle,
-        confirmationOnConfirm = confirmationOnConfirm
-    )
-}
-
-@Composable
-private fun CustomDialog(
-    content: @Composable () -> Unit,
-    title: @Composable () -> Unit,
-    buttonContentConfirm: @Composable RowScope.() -> Unit,
-    buttonContentDismiss: @Composable RowScope.() -> Unit,
-    onDismiss: () -> Unit,
-    show: Boolean,
-    confirmationTitle: @Composable () -> Unit = { Text("Confirm to proceed") },
-    confirmationDescription: @Composable () -> Unit = { },
-    confirmationOnConfirm: () -> Unit
-) {
-    if (!show) {
-        return
-    }
-
-    AlertDialog(
-        confirmButton = {
-            Box(contentAlignment = Alignment.BottomEnd) {
-                ButtonConfirm(
-                    border = BorderStroke(
-                        1.dp,
-                        Color.Red
-                    ),
-                    colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.Red),
-                    content = buttonContentConfirm,
-                    confirmationButtonContent = buttonContentConfirm,
-                    confirmationDescription = confirmationDescription,
-                    confirmationTitle = confirmationTitle,
-                    onConfirm = confirmationOnConfirm
-                )
-            }
-        },
-        containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        dismissButton = {
-            Box(contentAlignment = Alignment.BottomEnd) {
-                OutlinedButton(
-                    content = buttonContentDismiss,
-                    onClick = onDismiss,
-                    shape = MaterialTheme.shapes.extraLarge
-                )
-            }
-        },
-        onDismissRequest = onDismiss,
-        shape = MaterialTheme.shapes.extraSmall,
-        text = content,
-        textContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
-        title = title,
-        titleContentColor = MaterialTheme.colorScheme.onSurfaceVariant
-    )
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendsScreen.kt
@@ -56,6 +56,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import com.pvp.app.ui.common.ButtonWithDialog
 import com.pvp.app.ui.common.ProgressIndicator
+import com.pvp.app.ui.router.Routes
 
 private enum class SortingType {
     EXPERIENCE,
@@ -312,7 +313,9 @@ fun FriendsScreen(
             onSelect = { friend ->
                 model.select(friend.user.email)
 
-                controller.navigate("friend")
+                controller.navigate(Routes.Friend.path) {
+                    launchSingleTop = true
+                }
             },
             scrollState = scrollState
         )

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendsScreen.kt
@@ -54,7 +54,6 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
-import androidx.navigation.compose.currentBackStackEntryAsState
 import com.pvp.app.ui.common.ButtonWithDialog
 import com.pvp.app.ui.common.ProgressIndicatorWithinDialog
 import com.pvp.app.ui.router.Routes
@@ -68,10 +67,8 @@ private enum class SortingType {
 fun FriendsScreen(
     controller: NavHostController,
     model: FriendsViewModel = hiltViewModel(),
-    modifier: Modifier,
-    resolveOptions: () -> Unit
+    modifier: Modifier
 ) {
-    val backstack by controller.currentBackStackEntryAsState()
     val state by model.stateFriends.collectAsStateWithLifecycle()
 
     HandleState(
@@ -79,13 +76,6 @@ fun FriendsScreen(
         { model.resetFriendsScreenState() },
         state.state
     )
-
-    // TODO: Remove this when the issue is fixed
-    LaunchedEffect(backstack?.destination?.route == Routes.Friends.path) {
-        if (backstack?.destination?.route == Routes.Friends.path) {
-            resolveOptions()
-        }
-    }
 
     val context = LocalContext.current
     val friendEmail = remember { mutableStateOf("") }

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/Models.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/Models.kt
@@ -1,0 +1,52 @@
+package com.pvp.app.ui.screen.friends
+
+import androidx.compose.ui.graphics.ImageBitmap
+import com.pvp.app.model.FriendObject
+import com.pvp.app.model.Friends
+import com.pvp.app.model.User
+
+data class FriendEntry(
+    val avatar: ImageBitmap = ImageBitmap(
+        1,
+        1
+    ),
+    val user: User = User()
+)
+
+data class FriendState(
+    val details: Friends = Friends(),
+    val entry: FriendEntry = FriendEntry(),
+    val friendsMutual: List<FriendEntry> = emptyList(),
+    val state: FriendScreenState = FriendScreenState.Loading,
+    val tasksCompleted: Int = 0
+)
+
+sealed class FriendScreenState {
+
+    data object Finished : FriendScreenState()
+
+    data object Loading : FriendScreenState()
+
+    data object NoOperation : FriendScreenState()
+}
+
+data class FriendsState(
+    val friendObject: FriendObject = FriendObject(),
+    val friends: List<FriendEntry> = emptyList(),
+    val state: FriendsScreenState = FriendsScreenState.Loading,
+    val user: User = User()
+)
+
+sealed class FriendsScreenState {
+
+    data object Loading : FriendsScreenState()
+
+    data object NoOperation : FriendsScreenState()
+
+    sealed class Finished : FriendsScreenState() {
+
+        data object SelectedFriend : Finished()
+
+        companion object : Finished()
+    }
+}

--- a/app/src/main/java/com/pvp/app/ui/screen/goals/GoalScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/goals/GoalScreen.kt
@@ -15,11 +15,14 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material3.FabPosition
+import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.LinearProgressIndicator
@@ -44,7 +47,6 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pvp.app.model.Goal
-import com.pvp.app.ui.screen.layout.FloatingActionButton
 
 @Composable
 fun GoalScreen(
@@ -115,7 +117,16 @@ fun GoalScreen(
             )
         },
         floatingActionButton = {
-            FloatingActionButton(toggleDialog)
+            FloatingActionButton(
+                containerColor = MaterialTheme.colorScheme.primary,
+                onClick = toggleDialog,
+                shape = CircleShape
+            ) {
+                Icon(
+                    contentDescription = "Create goal",
+                    imageVector = Icons.Outlined.Add
+                )
+            }
         },
         floatingActionButtonPosition = FabPosition.End,
     )

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
@@ -24,19 +24,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ArrowBack
 import androidx.compose.material.icons.filled.Close
-import androidx.compose.material.icons.outlined.Add
 import androidx.compose.material.icons.outlined.Dehaze
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FabPosition
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -75,7 +71,6 @@ import com.pvp.app.ui.common.lighten
 import com.pvp.app.ui.router.Route
 import com.pvp.app.ui.router.Router
 import com.pvp.app.ui.router.Routes
-import com.pvp.app.ui.screen.calendar.TaskCreateDialog
 import com.pvp.app.ui.screen.drawer.DrawerScreen
 import com.pvp.app.ui.screen.profile.ProfileScreen
 import kotlinx.coroutines.CoroutineScope
@@ -214,20 +209,6 @@ private fun Content(
 
             1 -> ProfileScreen(modifier = modifier)
         }
-    }
-}
-
-@Composable
-private fun FloatingActionButton(onClick: () -> Unit) {
-    FloatingActionButton(
-        containerColor = MaterialTheme.colorScheme.primary,
-        onClick = onClick,
-        shape = CircleShape
-    ) {
-        Icon(
-            contentDescription = "Add task",
-            imageVector = Icons.Outlined.Add
-        )
     }
 }
 
@@ -376,16 +357,7 @@ fun LayoutScreenAuthenticated(
         drawerState = stateDrawer,
         gesturesEnabled = stateDrawer.isOpen
     ) {
-        var isTaskDialogOpen by remember { mutableStateOf(false) }
-        val toggleTaskDialog = remember { { isTaskDialogOpen = !isTaskDialogOpen } }
-
         Scaffold(
-            floatingActionButton = {
-                if (statePager.currentPage != 1 && route.first == Routes.Calendar) {
-                    FloatingActionButton(toggleTaskDialog)
-                }
-            },
-            floatingActionButtonPosition = FabPosition.End,
             topBar = {
                 val showBack = route.second != null && showBackNavigation(
                     route.second!!,
@@ -426,14 +398,6 @@ fun LayoutScreenAuthenticated(
                     controller = controller,
                     paddingValues = padding,
                     state = statePager
-                )
-            }
-
-            if (statePager.currentPage != 1 && route.first == Routes.Calendar) {
-                TaskCreateDialog(
-                    onClose = toggleTaskDialog,
-                    isOpen = isTaskDialogOpen,
-                    shouldCloseOnSubmit = true
                 )
             }
         }

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
@@ -113,7 +113,7 @@ private fun rememberRoute(controller: NavHostController): Pair<Route, NavDestina
 
     return remember(destination) {
         Pair(
-            Routes.routesAuthenticated.find {
+            Routes.authenticated.find {
                 it.path == destination?.route ||
                         it.path == destination?.parent?.route
             } ?: Routes.Calendar,
@@ -132,7 +132,7 @@ private fun showBackNavigation(
         page
     ) {
         page == 0 &&
-                destination.route !in Routes.routesDrawer.map { it.path } &&
+                destination.route !in Routes.drawer.map { it.path } &&
                 destination.parent?.startDestinationRoute != destination.route
     }
 }
@@ -199,7 +199,7 @@ private fun Content(
                 controller = controller,
                 start = Routes.Calendar,
                 routeModifier = modifier,
-                routes = Routes.routesAuthenticated
+                routes = Routes.authenticated
             )
 
             1 -> ProfileScreen(modifier = modifier)
@@ -346,7 +346,7 @@ fun LayoutScreenAuthenticated(
                     )
                 },
                 if (statePager.currentPage == 1) Routes.None else route.first,
-                Routes.routesDrawer
+                Routes.drawer
             )
         },
         drawerState = stateDrawer,

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
@@ -69,6 +69,7 @@ import com.pvp.app.ui.common.LocalHorizontalPagerSettled
 import com.pvp.app.ui.common.LocalRouteOptions
 import com.pvp.app.ui.common.LocalRouteOptionsApplier
 import com.pvp.app.ui.common.lighten
+import com.pvp.app.ui.common.navigateWithPopUp
 import com.pvp.app.ui.router.Route
 import com.pvp.app.ui.router.Router
 import com.pvp.app.ui.router.Routes
@@ -167,14 +168,7 @@ private fun switchPage(
     stateDrawer: DrawerState,
     statePager: PagerState
 ) {
-    controller.navigate(path) {
-        popUpTo(controller.graph.startDestinationId) {
-            saveState = true
-        }
-
-        launchSingleTop = true
-        restoreState = true
-    }
+    controller.navigateWithPopUp(path)
 
     scope.launch { stateDrawer.close() }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenAuthenticated.kt
@@ -65,6 +65,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import com.pvp.app.model.Decoration
 import com.pvp.app.model.Reward
 import com.pvp.app.ui.common.AsyncImage
+import com.pvp.app.ui.common.LocalHorizontalPagerSettled
 import com.pvp.app.ui.common.LocalRouteOptions
 import com.pvp.app.ui.common.LocalRouteOptionsApplier
 import com.pvp.app.ui.common.lighten
@@ -391,6 +392,7 @@ fun LayoutScreenAuthenticated(
             }
         ) { padding ->
             CompositionLocalProvider(
+                LocalHorizontalPagerSettled provides !statePager.isScrollInProgress,
                 LocalRouteOptions provides options,
                 LocalRouteOptionsApplier provides { options = it(options) }
             ) {

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenBootstrap.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenBootstrap.kt
@@ -11,7 +11,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.rememberNavController
 import com.pvp.app.ui.common.LocalBackgroundColors
-import com.pvp.app.ui.common.ProgressIndicatorWithinDialog
+import com.pvp.app.ui.common.ProgressIndicator
 import com.pvp.app.ui.common.backgroundGradientVertical
 import com.pvp.app.ui.router.Routes
 import com.pvp.app.ui.theme.BackgroundGradientSunset
@@ -39,7 +39,9 @@ fun LayoutScreenBootstrap(model: LayoutViewModel = hiltViewModel()) {
             val state by model.state.collectAsStateWithLifecycle()
 
             when {
-                state.isLoading -> ProgressIndicatorWithinDialog()
+                state.isLoading -> {
+                    ProgressIndicator()
+                }
 
                 !state.isAuthenticated || state.areSurveysFilled == false -> {
                     LayoutScreenUnauthenticated(
@@ -49,7 +51,9 @@ fun LayoutScreenBootstrap(model: LayoutViewModel = hiltViewModel()) {
                     )
                 }
 
-                else -> LayoutScreenAuthenticated(controller = rememberNavController())
+                else -> {
+                    LayoutScreenAuthenticated(controller = rememberNavController())
+                }
             }
         }
     }

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenBootstrap.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenBootstrap.kt
@@ -21,9 +21,9 @@ import com.pvp.app.ui.theme.BackgroundGradientSunset
  * are not initialized until the first time they are accessed.
  */
 private fun initializeRouteSingleton() {
-    Routes.routesAuthenticated
-    Routes.routesUnauthenticated
-    Routes.routesDrawer
+    Routes.authenticated
+    Routes.unauthenticated
+    Routes.drawer
 }
 
 @Composable

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenBootstrap.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenBootstrap.kt
@@ -11,7 +11,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.rememberNavController
 import com.pvp.app.ui.common.LocalBackgroundColors
-import com.pvp.app.ui.common.ProgressIndicator
+import com.pvp.app.ui.common.ProgressIndicatorWithinDialog
 import com.pvp.app.ui.common.backgroundGradientVertical
 import com.pvp.app.ui.router.Routes
 import com.pvp.app.ui.theme.BackgroundGradientSunset
@@ -39,9 +39,7 @@ fun LayoutScreenBootstrap(model: LayoutViewModel = hiltViewModel()) {
             val state by model.state.collectAsStateWithLifecycle()
 
             when {
-                state.isLoading -> {
-                    ProgressIndicator()
-                }
+                state.isLoading -> ProgressIndicatorWithinDialog()
 
                 !state.isAuthenticated || state.areSurveysFilled == false -> {
                     LayoutScreenUnauthenticated(
@@ -51,9 +49,7 @@ fun LayoutScreenBootstrap(model: LayoutViewModel = hiltViewModel()) {
                     )
                 }
 
-                else -> {
-                    LayoutScreenAuthenticated(controller = rememberNavController())
-                }
+                else -> LayoutScreenAuthenticated(controller = rememberNavController())
             }
         }
     }

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenBootstrap.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenBootstrap.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -14,7 +13,7 @@ import androidx.navigation.compose.rememberNavController
 import com.pvp.app.ui.common.LocalBackgroundColors
 import com.pvp.app.ui.common.ProgressIndicator
 import com.pvp.app.ui.common.backgroundGradientVertical
-import com.pvp.app.ui.router.Route
+import com.pvp.app.ui.router.Routes
 import com.pvp.app.ui.theme.BackgroundGradientSunset
 
 /**
@@ -22,9 +21,9 @@ import com.pvp.app.ui.theme.BackgroundGradientSunset
  * are not initialized until the first time they are accessed.
  */
 private fun initializeRouteSingleton() {
-    Route.routesAuthenticated
-    Route.routesUnauthenticated
-    Route.routesDrawer
+    Routes.routesAuthenticated
+    Routes.routesUnauthenticated
+    Routes.routesDrawer
 }
 
 @Composable
@@ -48,16 +47,12 @@ fun LayoutScreenBootstrap(model: LayoutViewModel = hiltViewModel()) {
                     LayoutScreenUnauthenticated(
                         areSurveysFilled = state.areSurveysFilled,
                         controller = rememberNavController(),
-                        isAuthenticated = state.isAuthenticated,
-                        scope = rememberCoroutineScope()
+                        isAuthenticated = state.isAuthenticated
                     )
                 }
 
                 else -> {
-                    LayoutScreenAuthenticated(
-                        controller = rememberNavController(),
-                        scope = rememberCoroutineScope()
-                    )
+                    LayoutScreenAuthenticated(controller = rememberNavController())
                 }
             }
         }

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenUnauthenticated.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenUnauthenticated.kt
@@ -3,10 +3,15 @@ package com.pvp.app.ui.screen.layout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import com.pvp.app.ui.common.LocalBackgroundColors
+import com.pvp.app.ui.common.LocalHorizontalPagerSettled
+import com.pvp.app.ui.common.LocalRouteOptions
+import com.pvp.app.ui.common.LocalRouteOptionsApplier
 import com.pvp.app.ui.common.backgroundGradientVertical
+import com.pvp.app.ui.router.Route
 import com.pvp.app.ui.router.Router
 import com.pvp.app.ui.router.Routes
 
@@ -17,17 +22,23 @@ fun LayoutScreenUnauthenticated(
     isAuthenticated: Boolean
 ) {
     Surface(modifier = Modifier.fillMaxSize()) {
-        Router(
-            controller = controller,
-            start = if (isAuthenticated && areSurveysFilled == false) {
-                Routes.Survey
-            } else {
-                Routes.Authentication
-            },
-            modifier = Modifier
-                .fillMaxSize()
-                .backgroundGradientVertical(LocalBackgroundColors.current),
-            routes = Routes.routesUnauthenticated,
-        )
+        CompositionLocalProvider(
+            LocalHorizontalPagerSettled provides true,
+            LocalRouteOptions provides Route.Options.None,
+            LocalRouteOptionsApplier provides { },
+        ) {
+            Router(
+                controller = controller,
+                start = if (isAuthenticated && areSurveysFilled == false) {
+                    Routes.Survey
+                } else {
+                    Routes.Authentication
+                },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .backgroundGradientVertical(LocalBackgroundColors.current),
+                routes = Routes.routesUnauthenticated,
+            )
+        }
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenUnauthenticated.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenUnauthenticated.kt
@@ -37,7 +37,7 @@ fun LayoutScreenUnauthenticated(
                 modifier = Modifier
                     .fillMaxSize()
                     .backgroundGradientVertical(LocalBackgroundColors.current),
-                routes = Routes.routesUnauthenticated,
+                routes = Routes.unauthenticated,
             )
         }
     }

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenUnauthenticated.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutScreenUnauthenticated.kt
@@ -7,30 +7,27 @@ import androidx.compose.ui.Modifier
 import androidx.navigation.NavHostController
 import com.pvp.app.ui.common.LocalBackgroundColors
 import com.pvp.app.ui.common.backgroundGradientVertical
-import com.pvp.app.ui.router.Route
 import com.pvp.app.ui.router.Router
-import kotlinx.coroutines.CoroutineScope
+import com.pvp.app.ui.router.Routes
 
 @Composable
 fun LayoutScreenUnauthenticated(
     areSurveysFilled: Boolean?,
     controller: NavHostController,
-    isAuthenticated: Boolean,
-    scope: CoroutineScope
+    isAuthenticated: Boolean
 ) {
     Surface(modifier = Modifier.fillMaxSize()) {
         Router(
             controller = controller,
-            destinationStart = if (isAuthenticated && areSurveysFilled == false) {
-                Route.Survey
+            start = if (isAuthenticated && areSurveysFilled == false) {
+                Routes.Survey
             } else {
-                Route.Authentication
+                Routes.Authentication
             },
             modifier = Modifier
                 .fillMaxSize()
                 .backgroundGradientVertical(LocalBackgroundColors.current),
-            routes = Route.routesUnauthenticated,
-            scope = scope
+            routes = Routes.routesUnauthenticated,
         )
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/layout/LayoutViewModel.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.update
@@ -55,7 +56,7 @@ class LayoutViewModel @Inject constructor(
                     needsStreakReward = streakService.checkStreak()
                 )
             }
-                .collect { state ->
+                .collectLatest { state ->
                     _state.update {
                         it.copy(
                             areSurveysFilled = state.areSurveysFilled,
@@ -68,10 +69,10 @@ class LayoutViewModel @Inject constructor(
                 }
         }
 
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             decorationService
                 .getAvatar(userService.user.filterNotNull())
-                .collect { avatar -> _state.update { it.copy(avatar = avatar) } }
+                .collectLatest { avatar -> _state.update { it.copy(avatar = avatar) } }
         }
     }
 
@@ -80,7 +81,7 @@ class LayoutViewModel @Inject constructor(
     }
 
     suspend fun giveReward() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             _reward.value = rewardService.get()
 
             rewardService.rewardUser(

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
@@ -53,7 +53,7 @@ import com.pvp.app.ui.common.ButtonConfirm
 import com.pvp.app.ui.common.EditableInfoItem
 import com.pvp.app.ui.common.Experience
 import com.pvp.app.ui.common.IconButtonWithDialog
-import com.pvp.app.ui.common.ProgressIndicator
+import com.pvp.app.ui.common.ProgressIndicatorWithinDialog
 import com.pvp.app.ui.common.showToast
 import kotlinx.coroutines.launch
 
@@ -247,9 +247,7 @@ fun ProfileScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
 
     if (state.isLoading) {
-        ProgressIndicator()
-
-        return
+        ProgressIndicatorWithinDialog()
     }
 
     Box(
@@ -260,18 +258,22 @@ fun ProfileScreen(
         Points(points = state.user.points)
 
         Column(modifier = Modifier.fillMaxWidth()) {
-            Initials(
-                onUsernameChange = {
-                    viewModel.update { u -> u.username = it }
-                },
-                state = state
-            )
+            if (!state.isLoading) {
+                Initials(
+                    onUsernameChange = {
+                        viewModel.update { u -> u.username = it }
+                    },
+                    state = state
+                )
 
-            Experience(
-                experience = state.user.experience,
-                experienceRequired = state.experienceRequired,
-                level = state.user.level
-            )
+                Experience(
+                    experience = state.user.experience,
+                    experienceRequired = state.experienceRequired,
+                    level = state.user.level
+                )
+            } else {
+                Spacer(modifier = Modifier.height(180.dp))
+            }
 
             Properties(
                 onUpdateActivities = { viewModel.update { u -> u.activities = it } },

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
@@ -2,7 +2,6 @@
 
 package com.pvp.app.ui.screen.profile
 
-import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -56,6 +55,7 @@ import com.pvp.app.ui.common.ButtonConfirm
 import com.pvp.app.ui.common.EditableInfoItem
 import com.pvp.app.ui.common.Experience
 import com.pvp.app.ui.common.IconButtonWithDialog
+import com.pvp.app.ui.common.LocalHorizontalPagerSettled
 import com.pvp.app.ui.common.LocalRouteOptionsApplier
 import com.pvp.app.ui.common.ProgressIndicatorWithinDialog
 import com.pvp.app.ui.common.RouteUtil.RouteTitle
@@ -479,7 +479,8 @@ private fun Properties(
 
 @Composable
 private fun RouteOptionsApplier() {
-    var applierRequired by remember { mutableStateOf(true) }
+    val settled = LocalHorizontalPagerSettled.current
+    var applierRequired by remember(settled) { mutableStateOf(settled) }
 
     if (applierRequired) {
         LocalRouteOptionsApplier.current {
@@ -489,12 +490,6 @@ private fun RouteOptionsApplier() {
         }
 
         applierRequired = false
-
-        // TODO: Delete in PR
-        Log.d(
-            "Applied options",
-            "-- @profile --"
-        )
     }
 }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
@@ -41,20 +41,25 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.pvp.app.R
 import com.pvp.app.model.Ingredient
 import com.pvp.app.model.SportActivity
 import com.pvp.app.ui.common.ButtonConfirm
 import com.pvp.app.ui.common.EditableInfoItem
 import com.pvp.app.ui.common.Experience
 import com.pvp.app.ui.common.IconButtonWithDialog
+import com.pvp.app.ui.common.LocalRouteOptionsApplier
 import com.pvp.app.ui.common.ProgressIndicatorWithinDialog
+import com.pvp.app.ui.common.RouteUtil.RouteTitle
 import com.pvp.app.ui.common.showToast
+import com.pvp.app.ui.router.Route
 import kotlinx.coroutines.launch
 
 private val ACTIVITIES = SportActivity.entries.map { it.title }
@@ -249,6 +254,8 @@ fun ProfileScreen(
     if (state.isLoading) {
         ProgressIndicatorWithinDialog()
     }
+
+    RouteOptionsApplier()
 
     Box(
         modifier = Modifier
@@ -470,6 +477,21 @@ private fun Properties(
             selectedFilters = ingredientsSelected,
             title = "Ingredients that you can't take"
         )
+    }
+}
+
+@Composable
+private fun RouteOptionsApplier() {
+    var applierRequired by remember { mutableStateOf(true) }
+
+    if (applierRequired) {
+        LocalRouteOptionsApplier.current {
+            Route.Options(title = {
+                RouteTitle(stringResource(R.string.route_profile))
+            })
+        }
+
+        applierRequired = false
     }
 }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
@@ -218,9 +218,7 @@ private fun Initials(
 }
 
 @Composable
-private fun BoxScope.Points(
-    points: Int
-) {
+private fun BoxScope.Points(points: Int) {
     Row(
         horizontalArrangement = Arrangement.Center,
         modifier = Modifier
@@ -267,9 +265,7 @@ fun ProfileScreen(
         Column(modifier = Modifier.fillMaxWidth()) {
             if (!state.isLoading) {
                 Initials(
-                    onUsernameChange = {
-                        viewModel.update { u -> u.username = it }
-                    },
+                    onUsernameChange = { viewModel.update { u -> u.username = it } },
                     state = state
                 )
 
@@ -308,9 +304,9 @@ private fun Properties(
     }
 
     var activitiesSelectedEdit by remember { mutableStateOf(activitiesSelected) }
-    var activitiesUnselected by remember { mutableStateOf(ACTIVITIES - activitiesSelected.toSet()) }
+    var activitiesUnselected by remember(activitiesSelected) { mutableStateOf(ACTIVITIES - activitiesSelected.toSet()) }
     val context = LocalContext.current
-    var height by remember { mutableIntStateOf(state.user.height) }
+    var height by remember(state.user.height) { mutableIntStateOf(state.user.height) }
     var heightEdit by remember { mutableStateOf(height.toString()) }
 
     var ingredientsSelected = remember(state.user.ingredients) {
@@ -319,7 +315,7 @@ private fun Properties(
 
     var ingredientsSelectedEdit by remember { mutableStateOf(ingredientsSelected) }
     var ingredientsUnselectedEdit by remember { mutableStateOf(INGREDIENTS - ingredientsSelected.toSet()) }
-    var mass by remember { mutableIntStateOf(state.user.mass) }
+    var mass by remember(state.user.mass) { mutableIntStateOf(state.user.mass) }
     var massEdit by remember { mutableStateOf(mass.toString()) }
 
     Column(
@@ -542,8 +538,8 @@ private fun Username(
 
 @Composable
 fun WeeklyActivitiesItem(
-    title: String,
-    activities: List<String>
+    activities: List<String>,
+    title: String
 ) {
     Box(
         modifier = Modifier
@@ -559,9 +555,9 @@ fun WeeklyActivitiesItem(
             verticalArrangement = Arrangement.Center
         ) {
             Row(
+                horizontalArrangement = Arrangement.SpaceBetween,
                 modifier = Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
+                verticalAlignment = Alignment.CenterVertically
             ) {
                 Column(
                     horizontalAlignment = Alignment.Start,
@@ -574,7 +570,10 @@ fun WeeklyActivitiesItem(
                 }
             }
 
-            FiltersBox(filters = activities)
+            FiltersBox(
+                filters = activities,
+                title = "weekly activities"
+            )
         }
     }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
@@ -58,7 +58,7 @@ import com.pvp.app.ui.common.IconButtonWithDialog
 import com.pvp.app.ui.common.LocalHorizontalPagerSettled
 import com.pvp.app.ui.common.LocalRouteOptionsApplier
 import com.pvp.app.ui.common.ProgressIndicatorWithinDialog
-import com.pvp.app.ui.common.RouteUtil.RouteTitle
+import com.pvp.app.ui.common.RouteTitle
 import com.pvp.app.ui.common.showToast
 import com.pvp.app.ui.router.Route
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
@@ -2,6 +2,7 @@
 
 package com.pvp.app.ui.screen.profile
 
+import android.util.Log
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -488,6 +489,12 @@ private fun RouteOptionsApplier() {
         }
 
         applierRequired = false
+
+        // TODO: Delete in PR
+        Log.d(
+            "Applied options",
+            "-- @profile --"
+        )
     }
 }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileViewModel.kt
@@ -15,6 +15,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
@@ -54,7 +55,7 @@ class ProfileViewModel @Inject constructor(
                         user = user
                     )
                 }
-                .collect { state -> _state.update { state } }
+                .collectLatest { state -> _state.update { state } }
         }
     }
 
@@ -76,7 +77,7 @@ class ProfileViewModel @Inject constructor(
     }
 
     fun update(function: (User) -> Unit) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             val user = _state.first().user.copy()
 
             function(user)

--- a/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
@@ -279,9 +279,9 @@ fun SettingsScreen(
 ) {
     Column(
         modifier = Modifier
-            .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .then(modifier)
+            .fillMaxSize()
             .padding(horizontal = 24.dp)
     ) {
         CategoryRow(

--- a/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
@@ -279,9 +279,9 @@ fun SettingsScreen(
 ) {
     Column(
         modifier = Modifier
+            .fillMaxSize()
             .verticalScroll(rememberScrollState())
             .then(modifier)
-            .fillMaxSize()
             .padding(horizontal = 24.dp)
     ) {
         CategoryRow(

--- a/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsViewModel.kt
@@ -6,6 +6,7 @@ import com.pvp.app.api.Configuration
 import com.pvp.app.api.SettingService
 import com.pvp.app.model.Setting
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.stateIn
@@ -19,7 +20,7 @@ class SettingsViewModel @Inject constructor(
 ) : ViewModel() {
 
     fun clear() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             settingService.clear()
         }
     }
@@ -38,7 +39,7 @@ class SettingsViewModel @Inject constructor(
         setting: Setting<T>,
         value: T
     ) {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             settingService.merge(setting, value)
         }
     }

--- a/app/src/main/java/com/pvp/app/ui/screen/steps/StepViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/steps/StepViewModel.kt
@@ -12,6 +12,7 @@ import com.pvp.app.api.HealthConnectService
 import com.pvp.app.common.ActivityUtil.toSportActivities
 import com.pvp.app.model.SportActivity
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
@@ -40,7 +41,7 @@ class StepViewModel @Inject constructor(
 
     @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
     fun updateTodaysSteps() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             val end = LocalDate
                 .now()
                 .plusDays(1)
@@ -60,7 +61,7 @@ class StepViewModel @Inject constructor(
     }
 
     fun getExercises() {
-        viewModelScope.launch {
+        viewModelScope.launch(Dispatchers.IO) {
             val end = Instant.now()
 
             val start = LocalDate

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="form_survey_toast_error">Submission was not successful</string>
     <string name="route_calendar">Calendar</string>
     <string name="route_decorations">Decorations</string>
+    <string name="route_friend">%1$s Profile</string>
     <string name="route_friends">Friends</string>
     <string name="route_goals">Goals</string>
     <string name="route_profile">Profile</string>


### PR DESCRIPTION
# Changes
- `Sidebar` is opened only by clicking the drawer icon-button. No more dragging.
- Routes are now registered as a `Root` (inner NavGraph) and as a `Node` (single route). This allows us to register inner graphs with routes that share the same view model/s in associated backstack.
- Changed navigation animation (when navigating between screens with navigation controller. this is not the case for `HorizontalPager` that allows us to access `Profile` screen)
- Friend preview was transferred to another screen.
- `FriendViewModel` code was reworked to use states instead of multiple variables.
- Some other `ViewModels` were adjusted to use flows in a more correct form (in my opinion), also coroutines are using IO dispatcher in most places now.
- Dialog to create task moved to bottom sheet.
- Dialog to edit task moved to bottom sheet.
- Added a few new `Local` variables that help to handle dynamic route options: icon, title.
  - Options are handled statically by Router, but in route's composable we can alter it further depending on our set conditions. Currently Friend and Profile screens are doing exactly that.
- Transferred some logic regarding tasks from `Layout` to `Calendar` screen.
- Added loading states to pages that load data: `profile`, `friends`, `friend`, `decorations` and using new `ProgressIndicatorWithinDialog` component that allows us to see changes being made under the dialog, while composable is working with currently-loading data.
  - `Calendar` screen is not using it, I think we may not need such logic there.
- Tasks preview form by default has `Daily` tasks group set instead of `General`.
- Tasks edit/create forms are using `Picker` for `Duration`, `ReminderTime` properties instead of `Slider`.
  - Also, Sport task creation form by default has `Walking` activity set and it is shown to the user. Before it wasn't shown to the user, but we defaulted to `Walking` activity either way, if users didn't set activity themselves.