### PR TITLE
PVP-239 Make EditableInfoItem smaller when it's empty

### DIFF
--- a/app/src/main/java/com/pvp/app/api/Configuration.kt
+++ b/app/src/main/java/com/pvp/app/api/Configuration.kt
@@ -34,6 +34,11 @@ interface Configuration {
     val rangeCupVolume: List<Int>
 
     /**
+     * Duration values for the user to select from.
+     */
+    val rangeDuration: List<Int>
+
+    /**
      * Height values for the user to select from.
      */
     val rangeHeight: List<Int>
@@ -41,8 +46,7 @@ interface Configuration {
     /**
      * Kilometers values for the user to select from.
      *
-     * It should be used together with meters in some picker component. User could select the range
-     * of kilometers provided in this list and also meters in range of 0-999.
+     * It should be used together with meters in some picker component.
      */
     val rangeKilometers: List<Int>
 
@@ -60,11 +64,6 @@ interface Configuration {
      * Reminder minutes values for the user to select from.
      */
     val rangeReminderMinutes: List<Int>
-
-    /**
-     * Duration values for the user to select from.
-     */
-    val rangeDuration: List<Int>
 
     /**
      * The inclusive interval of hours during which water drinking reminders are being sent.

--- a/app/src/main/java/com/pvp/app/api/Configuration.kt
+++ b/app/src/main/java/com/pvp/app/api/Configuration.kt
@@ -47,6 +47,11 @@ interface Configuration {
     val rangeKilometers: List<Int>
 
     /**
+     * Meters values for the user to select from.
+     */
+    val rangeMeters: List<Int>
+
+    /**
      * Mass values for the user to select from.
      */
     val rangeMass: List<Int>
@@ -55,6 +60,11 @@ interface Configuration {
      * Reminder minutes values for the user to select from.
      */
     val rangeReminderMinutes: List<Int>
+
+    /**
+     * Duration values for the user to select from.
+     */
+    val rangeDuration: List<Int>
 
     /**
      * The inclusive interval of hours during which water drinking reminders are being sent.

--- a/app/src/main/java/com/pvp/app/service/ConfigurationImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/ConfigurationImpl.kt
@@ -21,28 +21,14 @@ class ConfigurationImpl @Inject constructor() : Configuration {
     override val limitPointsDeduction: Int = 5
     override val limitPointsReclaimDays: Int = 2
 
-    override val rangeCupVolume: List<Int> = (100..1000 step 50)
-        .toList()
+    override val rangeCupVolume: List<Int> = (100..1000 step 50).toList()
+    override val rangeHeight: List<Int> = (10..300).toList()
+    override val rangeKilometers: List<Int> = (0..99).toList()
+    override val rangeMeters: List<Int> = (0..1000 step 100).toList()
+    override val rangeMass: List<Int> = (5..500).toList()
+    override val rangeReminderMinutes: List<Int> = (0..120 step 5).toList()
+    override val rangeDuration: List<Int> = (0..300 step 5).toList()
 
-    override val rangeHeight: List<Int> = (10..300)
-        .toList()
-
-    override val rangeKilometers: List<Int> = (0..99)
-        .toList()
-
-    override val rangeMass: List<Int> = (5..500)
-        .toList()
-
-    override val rangeReminderMinutes: List<Int> = (1..120)
-        .toList()
-
-    override val intervalDrinkReminder: Pair<Int, Int> = Pair(
-        8,
-        22
-    )
-
-    override val intervalUsernameLength: Pair<Int, Int> = Pair(
-        3,
-        18
-    )
+    override val intervalDrinkReminder: Pair<Int, Int> = Pair(8, 22)
+    override val intervalUsernameLength: Pair<Int, Int> = Pair(3, 18)
 }

--- a/app/src/main/java/com/pvp/app/service/ConfigurationImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/ConfigurationImpl.kt
@@ -22,12 +22,12 @@ class ConfigurationImpl @Inject constructor() : Configuration {
     override val limitPointsReclaimDays: Int = 2
 
     override val rangeCupVolume: List<Int> = (100..1000 step 50).toList()
+    override val rangeDuration: List<Int> = (0..300 step 5).toList()
     override val rangeHeight: List<Int> = (10..300).toList()
     override val rangeKilometers: List<Int> = (0..99).toList()
     override val rangeMeters: List<Int> = (0..1000 step 100).toList()
     override val rangeMass: List<Int> = (5..500).toList()
     override val rangeReminderMinutes: List<Int> = (0..120 step 5).toList()
-    override val rangeDuration: List<Int> = (0..300 step 5).toList()
 
     override val intervalDrinkReminder: Pair<Int, Int> = Pair(8, 22)
     override val intervalUsernameLength: Pair<Int, Int> = Pair(3, 18)

--- a/app/src/main/java/com/pvp/app/service/NotificationServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/NotificationServiceImpl.kt
@@ -211,13 +211,12 @@ class NotificationServiceImpl @Inject constructor(
             return null
         }
 
-        var reminderMinutes = settingService
-            .get(Setting.Notifications.ReminderBeforeTaskMinutes)
-            .first().toLong()
-
-        if (task.reminderTime != null) {
-            reminderMinutes = task.reminderTime?.toMinutes() ?: reminderMinutes
-        }
+        val reminderMinutes = task.reminderTime
+            ?.toMinutes()
+            ?: settingService
+                .get(Setting.Notifications.ReminderBeforeTaskMinutes)
+                .first()
+                .toLong()
 
         val reminderDateTime = task.date
             .atTime(task.time)

--- a/app/src/main/java/com/pvp/app/ui/common/Components.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Components.kt
@@ -20,6 +20,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.rememberBasicTooltipState
 import androidx.compose.material.icons.Icons
@@ -288,7 +289,8 @@ fun Experience(
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
 fun InfoTooltip(
-    tooltipText: String
+    tooltipText: String,
+    iconSize: Dp = 24.dp
 ) {
     val tooltipState = rememberBasicTooltipState()
     val scope = rememberCoroutineScope()
@@ -317,9 +319,13 @@ fun InfoTooltip(
         state = tooltipState
     ) {
         IconButton(
+            modifier = Modifier.size(iconSize),
             onClick = { scope.launch { tooltipState.show() } },
         ) {
             Icon(
+                modifier = Modifier
+                    .size(iconSize)
+                    .padding(horizontal = 4.dp),
                 imageVector = Icons.Outlined.Info,
                 contentDescription = "Autocompletion of activity"
             )

--- a/app/src/main/java/com/pvp/app/ui/common/DateTimePickers.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/DateTimePickers.kt
@@ -51,7 +51,7 @@ fun DatePickerDialog(
     onDismiss: () -> Unit,
     onDateSelected: (LocalDateTime) -> Unit
 ) {
-    val date = rememberDatePickerState(initialDisplayMode = DisplayMode.Input)
+    val date = rememberDatePickerState(initialDisplayMode = DisplayMode.Picker)
 
     if (showPicker) {
         androidx.compose.material3.DatePickerDialog(

--- a/app/src/main/java/com/pvp/app/ui/common/Inputs.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Inputs.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -12,11 +13,17 @@ import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Edit
 import androidx.compose.material.icons.outlined.Error
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -24,8 +31,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.pvp.app.model.SportActivity
+import com.pvp.app.ui.common.PickerState.Companion.rememberPickerState
+import java.time.Duration
 import java.time.LocalDateTime
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
 /**
  * @param keyboardOptions (optional) software keyboard options that contains configuration such
@@ -228,8 +241,8 @@ fun EditableInfoItem(
 @Composable
 fun EditableDateItem(
     label: String,
-    value: String,
-    onDateSelected: (LocalDateTime) -> Unit
+    value: LocalDateTime,
+    onValueChange: (LocalDateTime) -> Unit
 ) {
     Box(
         modifier = Modifier
@@ -250,7 +263,7 @@ fun EditableDateItem(
                 text = label
             )
 
-            Text(value)
+            Text(value.format(DateTimeFormatter.ofPattern("yyyy-MM-dd, EEEE")))
         }
 
         IconButtonWithDatePickerDialog(
@@ -258,7 +271,306 @@ fun EditableDateItem(
             icon = Icons.Outlined.Edit,
             iconDescription = "Edit info item icon button",
             iconSize = 30.dp,
-            onDateSelected = onDateSelected
+            onDateSelected = onValueChange
         )
     }
+}
+
+@Composable
+fun EditableTextItem(
+    label: String,
+    value: String,
+    onValueChange: (String) -> Unit,
+) {
+    var editingText by remember { mutableStateOf(value) }
+
+    EditableInfoItem(
+        dialogContent = {
+            OutlinedTextField(
+                label = { Text(label) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = 16.dp),
+                onValueChange = { editingText = it },
+                value = editingText
+            )
+        },
+        dialogTitle = { Text("Editing $label") },
+        label = {
+            Text(
+                fontWeight = FontWeight.Bold,
+                text = label
+            )
+        },
+        onConfirm = {
+            onValueChange(editingText)
+        },
+        onDismiss = { },
+        value = {
+            if (value.isNotEmpty()) {
+                Text(value)
+            }
+        }
+    )
+}
+
+@Composable
+fun EditablePickerItem(
+    label: String,
+    value: Duration?,
+    valueLabel: String,
+    items: List<Int>,
+    itemsLabels: String,
+    onValueChange: (Duration) -> Unit,
+) {
+    var editingDuration by remember { mutableStateOf(value ?: Duration.ZERO) }
+
+    EditableInfoItem(
+        dialogContent = {
+            Column {
+                val initial = remember(editingDuration) {
+                    editingDuration
+                        ?.toMinutes()
+                        ?.toFloat()
+                        ?: 0f
+                }
+
+                Picker(
+                    label = { "$it $itemsLabels" },
+                    items = items,
+                    state = rememberPickerState(initialValue = initial),
+                    startIndex = initial.toInt() / 5,
+                    onChange = { editingDuration = Duration.ofMinutes(it.toLong()) }
+                )
+            }
+        },
+        dialogTitle = { Text("Editing $label") },
+        label = {
+            Text(
+                fontWeight = FontWeight.Bold,
+                text = label
+            )
+        },
+        onConfirm = {
+            onValueChange(editingDuration)
+        },
+        onDismiss = { },
+        value = {
+            if (value != null) {
+                Text("${value.toMinutes()} $valueLabel")
+            }
+        }
+    )
+}
+
+@Composable
+fun EditablePickerItem(
+    label: String,
+    value: Int,
+    valueLabel: String,
+    items: List<Int>,
+    itemsLabels: String,
+    onValueChange: (Int) -> Unit,
+) {
+    var editingValue by remember { mutableIntStateOf(value) }
+
+    EditableInfoItem(
+        dialogContent = {
+            Column {
+                Picker(
+                    label = { "$it $itemsLabels" },
+                    items = items,
+                    state = rememberPickerState(initialValue = editingValue),
+                    startIndex = editingValue - items.first(),
+                    onChange = { editingValue = it }
+                )
+            }
+        },
+        dialogTitle = { Text("Editing $label") },
+        label = {
+            Text(
+                fontWeight = FontWeight.Bold,
+                text = label
+            )
+        },
+        onConfirm = {
+            onValueChange(editingValue)
+        },
+        onDismiss = { },
+        value = { Text("$value $valueLabel") }
+    )
+}
+
+@Composable
+fun EditableTimeItem(
+    label: String,
+    value: LocalTime,
+    valueDisplay: String? = null,
+    onValueChange: (LocalTime) -> Unit,
+) {
+    val editingHour = rememberPickerState(value.hour)
+    val editingMinute = rememberPickerState(value.minute)
+
+    EditableInfoItem(
+        dialogContent = {
+            PickerTime(
+                selectedHour = editingHour,
+                selectedMinute = editingMinute,
+                onChange = { hour, minute ->
+                    editingHour.value = hour
+                    editingMinute.value = minute
+                }
+            )
+        },
+        dialogTitle = { Text("Editing $label") },
+        label = {
+            Text(
+                fontWeight = FontWeight.Bold,
+                text = label
+            )
+        },
+        onConfirm = {
+            onValueChange(LocalTime.of(editingHour.value, editingMinute.value))
+        },
+        onDismiss = { },
+        value = {
+            if (valueDisplay != null) {
+                Text(valueDisplay)
+            }
+        }
+    )
+}
+
+@Composable
+fun EditableDistanceItem(
+    label: String,
+    value: Double?,
+    rangeKilometers: List<Int>,
+    rangeMeters: List<Int>,
+    onValueChange: (Double) -> Unit,
+) {
+    val stateKilometers = rememberPickerState(
+        value
+            ?.toInt()
+            ?: rangeKilometers.first()
+    )
+
+    val stateMeters = rememberPickerState(
+        value
+            ?.let { ((it - stateKilometers.value) * 1000).toInt() }
+            ?: 0
+    )
+
+    EditableInfoItem(
+        dialogContent = {
+            LabelFieldWrapper(
+                content = {
+                    PickerPair(
+                        itemsFirst = rangeKilometers,
+                        itemsSecond = rangeMeters,
+                        labelFirst = { "$it (km)" },
+                        labelSecond = { "$it (m)" },
+                        onChange = { stateFirst, stateSecond ->
+                            stateKilometers.value = stateFirst
+                            stateMeters.value = stateSecond
+                        },
+                        stateFirst = stateKilometers,
+                        stateSecond = stateMeters
+                    )
+                },
+                putBelow = true,
+                text = "${stateKilometers.value + (stateMeters.value / 1000.0)} (km) distance",
+                textAlign = TextAlign.End
+            )
+        },
+        dialogTitle = { Text("Editing $label") },
+        label = {
+            Text(
+                fontWeight = FontWeight.Bold,
+                text = label
+            )
+        },
+        onConfirm = {
+            onValueChange(
+                stateKilometers.value + (stateMeters.value / 1000.0)
+            )
+        },
+        onDismiss = { },
+        value = {
+            if (value != null) {
+                Text("$value (km)")
+            }
+        }
+    )
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun EditableSportActivityItem(
+    label: String,
+    value: SportActivity,
+    onValueChange: (SportActivity) -> Unit,
+) {
+    var editingActivity by remember { mutableStateOf(value) }
+
+    EditableInfoItem(
+        dialogContent = {
+            var isExpanded by remember { mutableStateOf(false) }
+
+            ExposedDropdownMenuBox(
+                expanded = isExpanded,
+                onExpandedChange = { isExpanded = it },
+            ) {
+                androidx.compose.material3.TextField(
+                    modifier = Modifier
+                        .menuAnchor()
+                        .fillMaxWidth(),
+                    value = editingActivity.title,
+                    onValueChange = {},
+                    readOnly = true,
+                    trailingIcon = {
+                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpanded)
+                    }
+                )
+
+                ExposedDropdownMenu(
+                    expanded = isExpanded,
+                    onDismissRequest = { isExpanded = false }
+                ) {
+                    SportActivity.entries.forEach {
+                        DropdownMenuItem(
+                            text = { Text(text = it.title) },
+                            onClick = {
+                                editingActivity = it
+                                isExpanded = false
+                            }
+                        )
+                    }
+                }
+            }
+        },
+        dialogTitle = { Text("Editing $label") },
+        label = {
+            Text(
+                fontWeight = FontWeight.Bold,
+                text = label
+            )
+        },
+        onConfirm = {
+            onValueChange(editingActivity)
+        },
+        onDismiss = { },
+        value = {
+            Row(
+                Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Text(value.title)
+
+                if (value.supportsDistanceMetrics) {
+                    InfoTooltip(tooltipText = "This task is likely to be autocompleted")
+                }
+            }
+        }
+    )
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
@@ -51,7 +51,7 @@ fun TaskCard(
     if (showDialog) {
         TaskEditSheet(
             task,
-            onDialogClose = {
+            onClose = {
                 showDialog = false
             }
         )

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
@@ -1,190 +1,278 @@
 package com.pvp.app.ui.screen.calendar
 
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.DropdownMenuItem
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.ExposedDropdownMenuBox
-import androidx.compose.material3.ExposedDropdownMenuDefaults
-import androidx.compose.material3.Slider
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Delete
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.TextStyle
-import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportActivity
 import com.pvp.app.model.SportTask
-import com.pvp.app.ui.common.EditableInfoItem
-import com.pvp.app.ui.common.InfoTooltip
-import com.pvp.app.ui.common.LabelFieldWrapper
-import com.pvp.app.ui.common.PickerPair
-import com.pvp.app.ui.common.PickerState
-import java.time.Duration
+import com.pvp.app.model.Task
+import com.pvp.app.ui.common.Button
+import com.pvp.app.ui.common.ButtonConfirm
+import com.pvp.app.ui.common.EditableDateItem
+import com.pvp.app.ui.common.EditableDistanceItem
+import com.pvp.app.ui.common.EditablePickerItem
+import com.pvp.app.ui.common.EditableSportActivityItem
+import com.pvp.app.ui.common.EditableTextItem
+import com.pvp.app.ui.common.EditableTimeItem
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import kotlin.reflect.KClass
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun TaskEditFieldsSport(
-    task: SportTask? = null,
+fun TaskCommonForm(
     model: TaskViewModel = hiltViewModel(),
-    onActivityChange: (SportActivity?) -> Unit,
-    onDistanceChange: (Double) -> Unit,
-    onDurationChange: (Duration) -> Unit
+    date: LocalDateTime? = null,
+    task: Task? = null,
+    targetClass: KClass<out Task>? = null,
+    onDialogClose: () -> Unit,
 ) {
-    var activity by remember { mutableStateOf(task?.activity ?: SportActivity.Walking) }
-    var distance by remember { mutableDoubleStateOf(task?.distance ?: 0.0) }
-    var duration by remember { mutableStateOf(task?.duration ?: Duration.ZERO) }
-    var tempActivity by remember { mutableStateOf(activity) }
-    var tempDuration by remember { mutableStateOf(duration) }
+    if (task == null && targetClass == null) {
+        return
+    }
 
-    EditableInfoItem(
-        dialogContent = {
-            var isExpanded by remember { mutableStateOf(false) }
+    val taskClass = targetClass ?: task!!::class
+    val isCreateForm by remember { mutableStateOf(task == null) }
 
-            ExposedDropdownMenuBox(
-                expanded = isExpanded,
-                onExpandedChange = { isExpanded = it },
-            ) {
-                TextField(
-                    modifier = Modifier
-                        .menuAnchor()
-                        .fillMaxWidth(),
-                    value = tempActivity?.title ?: "",
-                    onValueChange = {},
-                    readOnly = true,
-                    trailingIcon = {
-                        ExposedDropdownMenuDefaults.TrailingIcon(expanded = isExpanded)
-                    }
-                )
-
-                ExposedDropdownMenu(
-                    expanded = isExpanded,
-                    onDismissRequest = { isExpanded = false }
-                ) {
-                    SportActivity.entries.forEach {
-                        DropdownMenuItem(
-                            text = { Text(text = it.title) },
-                            onClick = {
-                                tempActivity = it
-                                isExpanded = false
-                            }
-                        )
-                    }
-                }
-            }
-        },
-        dialogTitle = { Text("Editing activity") },
-        label = "Activity",
-        onConfirm = { activity = tempActivity },
-        onDismiss = { tempActivity = activity },
-        value = {
-            Row (
-                Modifier.fillMaxWidth(),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(activity?.title ?: "")
-
-                if (activity?.supportsDistanceMetrics == true) {
-                    InfoTooltip(tooltipText = "This task is likely to be autocompleted")
-                }
-            }
-        }
-    )
-
-    if (activity != null && activity!!.supportsDistanceMetrics) {
-        val stateKilometers = PickerState.rememberPickerState(
-            task?.distance
-                ?.toInt()
-                ?: model.rangeKilometers.first()
+    var title by remember { mutableStateOf(task?.title ?: "") }
+    var description by remember {
+        mutableStateOf(
+            (task as? MealTask)?.recipe ?: task?.description ?: ""
         )
-
-        val stateMeters = PickerState.rememberPickerState(
-            task?.distance
-                ?.let { ((it - stateKilometers.value) * 900).toInt() }
-                ?: 0
+    }
+    var activity by remember {
+        mutableStateOf(
+            (task as? SportTask)?.activity ?: SportActivity.Walking
         )
-
-        EditableInfoItem(
-            dialogContent = {
-                LabelFieldWrapper(
-                    content = {
-                        PickerPair(
-                            itemsFirst = model.rangeKilometers,
-                            itemsSecond = (0..1000 step 100).toList(),
-                            labelFirst = { "$it (km)" },
-                            labelSecond = { "$it (m)" },
-                            onChange = { stateFirst, stateSecond ->
-                                stateKilometers.value = stateFirst
-                                stateMeters.value = stateSecond
-                            },
-                            stateFirst = stateKilometers,
-                            stateSecond = stateMeters
-                        )
-                    },
-                    putBelow = true,
-                    text = "${stateKilometers.value + (stateMeters.value / 1000.0)} (km) distance",
-                    textAlign = TextAlign.End
-                )
-            },
-            dialogTitle = { Text("Editing distance") },
-            label = "Distance",
-            onConfirm = { distance = stateKilometers.value.toDouble() },
-            onDismiss = { distance = task?.distance ?: 0.0 },
-            value = "$distance (km)"
-        )
-    } else {
-        EditableInfoItem(
-            dialogContent = {
-                Column {
-                    Text(
-                        text = "Duration: ${tempDuration?.toMinutes()} minutes",
-                        style = TextStyle(fontSize = 16.sp),
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(start = 4.dp)
-                    )
-
-                    Slider(
-                        value = tempDuration
-                            ?.toMinutes()
-                            ?.toFloat() ?: 0f,
-                        onValueChange = { newValue ->
-                            tempDuration = Duration.ofMinutes(newValue.toLong())
-                        },
-                        valueRange = 1f..180f,
-                        steps = 180,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(
-                                start = 8.dp,
-                                end = 8.dp,
-                                bottom = 8.dp
-                            )
-                    )
-                }
-            },
-            dialogTitle = { Text("Editing duration") },
-            label = "Duration",
-            onConfirm = { duration = tempDuration },
-            onDismiss = { tempDuration = duration },
-            value = "${duration?.toMinutes()} minutes"
+    }
+    var duration by remember { mutableStateOf(task?.duration) }
+    var distance by remember { mutableStateOf((task as? SportTask)?.distance) }
+    var reminderTime by remember { mutableStateOf(task?.reminderTime) }
+    var dateTime by remember {
+        mutableStateOf(
+            if (task?.date != null && task.time != null) {
+                LocalDateTime.of(task.date, task.time)
+            } else date ?: LocalDateTime.now()
         )
     }
 
-    onActivityChange(activity)
+    val isFormValid by remember {
+        derivedStateOf {
+            title.isNotEmpty()
+        }
+    }
 
-    onDistanceChange(distance)
+    Column(
+        modifier = Modifier
+            .background(MaterialTheme.colorScheme.surfaceContainer)
+            .clip(MaterialTheme.shapes.medium)
+            .padding(8.dp)
+            .fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        EditableTextItem(
+            label = "Title",
+            value = title,
+            onValueChange = { title = it }
+        )
 
-    duration?.let { onDurationChange(it) }
+        EditableTextItem(
+            label = if (taskClass == MealTask::class) "Recipe" else "Description",
+            value = description,
+            onValueChange = { description = it }
+        )
+
+        if (targetClass == SportTask::class) {
+            EditableSportActivityItem(
+                label = "Activity",
+                value = activity,
+                onValueChange = { activity = it }
+            )
+        }
+
+        if (taskClass == SportTask::class && activity.supportsDistanceMetrics) {
+            EditableDistanceItem(
+                label = "Distance",
+                value = distance,
+                rangeKilometers = model.rangeKilometers,
+                rangeMeters = model.rangeMeters,
+                onValueChange = { distance = it }
+            )
+        }
+
+        if (taskClass != SportTask::class || !activity.supportsDistanceMetrics) {
+            EditablePickerItem(
+                label = "Duration",
+                value = duration,
+                valueLabel = "minutes",
+                items = model.rangeDuration,
+                itemsLabels = "minutes",
+                onValueChange = { duration = it }
+            )
+        }
+
+        EditableTimeItem(
+            label = "Scheduled at",
+            value = dateTime.toLocalTime(),
+            valueDisplay = if ((taskClass == SportTask::class && activity.supportsDistanceMetrics)
+                || duration == null
+            ) {
+                dateTime.format(DateTimeFormatter.ofPattern("HH:mm"))
+            } else {
+                "${dateTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - " +
+                        (dateTime.plus(duration)).format(DateTimeFormatter.ofPattern("HH:mm"))
+            },
+            onValueChange = {
+                dateTime = dateTime
+                    .withHour(it.hour)
+                    .withMinute(it.minute)
+            }
+        )
+
+        EditableDateItem(
+            label = "Date",
+            value = dateTime,
+            onValueChange = { dateTime = it }
+        )
+
+        EditablePickerItem(
+            label = "Reminder Time",
+            value = reminderTime,
+            valueLabel = "minutes before task",
+            items = model.rangeReminderTime,
+            itemsLabels = "minutes",
+            onValueChange = { reminderTime = it }
+        )
+
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = 24.dp,
+                    vertical = 15.dp
+                ),
+            horizontalArrangement = if (isCreateForm) Arrangement.Center else Arrangement.SpaceBetween
+        ) {
+            if (!isCreateForm) {
+                ButtonConfirm(
+                    border = BorderStroke(
+                        1.dp,
+                        Color.Red
+                    ),
+                    colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.Red),
+                    content = {
+                        Row(verticalAlignment = Alignment.CenterVertically) {
+                            Icon(
+                                contentDescription = "Delete task icon",
+                                imageVector = Icons.Outlined.Delete
+                            )
+
+                            Text(
+                                style = MaterialTheme.typography.titleSmall,
+                                text = "Delete"
+                            )
+                        }
+                    },
+                    confirmationButtonContent = { Text("Delete") },
+                    confirmationDescription = { Text("If the task is deleted, it cannot be recovered") },
+                    confirmationTitle = { Text("Are you sure you want to delete this task?") },
+                    onConfirm = {
+                        model.remove(task!!)
+
+                        onDialogClose()
+                    },
+                    shape = MaterialTheme.shapes.extraLarge
+                )
+            }
+
+            Button(
+                onClick = {
+                    if (isCreateForm) {
+                        when (targetClass) {
+                            SportTask::class -> model.create(
+                                date = dateTime.toLocalDate(),
+                                activity = activity,
+                                description = description,
+                                distance = distance,
+                                duration = duration,
+                                reminderTime = reminderTime,
+                                time = dateTime.toLocalTime(),
+                                title = title
+                            )
+
+                            MealTask::class -> model.create(
+                                date = dateTime.toLocalDate(),
+                                description = "",
+                                duration = duration,
+                                reminderTime = reminderTime,
+                                recipe = description,
+                                time = dateTime.toLocalTime(),
+                                title = title
+                            )
+
+                            else -> model.create(
+                                date = dateTime.toLocalDate(),
+                                description = description,
+                                duration = duration,
+                                reminderTime = reminderTime,
+                                time = dateTime.toLocalTime(),
+                                title = title
+                            )
+                        }
+                    } else {
+                        model.update(
+                            { task ->
+                                task.title = title
+                                task.description = description
+                                task.duration = duration
+                                task.reminderTime = reminderTime
+                                task.date = dateTime.toLocalDate()
+                                task.time = dateTime.toLocalTime()
+
+                                when (task) {
+                                    is SportTask -> {
+                                        task.activity = activity
+                                        task.distance = distance
+                                    }
+
+                                    is MealTask -> {
+                                        task.recipe = description
+                                        task.description = ""
+                                    }
+                                }
+                            },
+                            task!!
+                        )
+                    }
+
+                    onDialogClose()
+                },
+                enabled = isFormValid
+            ) {
+                Text(if (isCreateForm) "Create" else "Update")
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCommon.kt
@@ -47,7 +47,7 @@ fun TaskCommonForm(
     date: LocalDateTime? = null,
     task: Task? = null,
     targetClass: KClass<out Task>? = null,
-    onDialogClose: () -> Unit,
+    onClose: () -> Unit,
 ) {
     if (task == null && targetClass == null) {
         return
@@ -55,25 +55,30 @@ fun TaskCommonForm(
 
     val taskClass = targetClass ?: task!!::class
     val isCreateForm by remember { mutableStateOf(task == null) }
-
     var title by remember { mutableStateOf(task?.title ?: "") }
+    var duration by remember { mutableStateOf(task?.duration) }
+    var distance by remember { mutableStateOf((task as? SportTask)?.distance) }
+    var reminderTime by remember { mutableStateOf(task?.reminderTime) }
+
     var description by remember {
         mutableStateOf(
             (task as? MealTask)?.recipe ?: task?.description ?: ""
         )
     }
+
     var activity by remember {
         mutableStateOf(
             (task as? SportTask)?.activity ?: SportActivity.Walking
         )
     }
-    var duration by remember { mutableStateOf(task?.duration) }
-    var distance by remember { mutableStateOf((task as? SportTask)?.distance) }
-    var reminderTime by remember { mutableStateOf(task?.reminderTime) }
+
     var dateTime by remember {
         mutableStateOf(
             if (task?.date != null && task.time != null) {
-                LocalDateTime.of(task.date, task.time)
+                LocalDateTime.of(
+                    task.date,
+                    task.time
+                )
             } else date ?: LocalDateTime.now()
         )
     }
@@ -136,8 +141,10 @@ fun TaskCommonForm(
         EditableTimeItem(
             label = "Scheduled at",
             value = dateTime.toLocalTime(),
-            valueDisplay = if ((taskClass == SportTask::class && activity.supportsDistanceMetrics)
-                || duration == null
+            valueDisplay = if (
+                (taskClass == SportTask::class &&
+                        activity.supportsDistanceMetrics) ||
+                duration == null
             ) {
                 dateTime.format(DateTimeFormatter.ofPattern("HH:mm"))
             } else {
@@ -201,7 +208,7 @@ fun TaskCommonForm(
                     onConfirm = {
                         model.remove(task!!)
 
-                        onDialogClose()
+                        onClose()
                     },
                     shape = MaterialTheme.shapes.extraLarge
                 )
@@ -267,7 +274,7 @@ fun TaskCommonForm(
                         )
                     }
 
-                    onDialogClose()
+                    onClose()
                 },
                 enabled = isFormValid
             ) {

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
@@ -3,7 +3,6 @@
 package com.pvp.app.ui.screen.calendar
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
@@ -11,21 +10,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.PrimaryTabRow
 import androidx.compose.material3.Tab
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableDoubleStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -34,20 +28,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import com.pvp.app.model.MealTask
-import com.pvp.app.model.SportActivity
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
-import com.pvp.app.ui.common.Button
-import com.pvp.app.ui.common.EditableDateItem
-import com.pvp.app.ui.common.EditableInfoItem
-import com.pvp.app.ui.common.Picker
-import com.pvp.app.ui.common.PickerState.Companion.rememberPickerState
-import com.pvp.app.ui.common.PickerTime
-import java.time.Duration
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import kotlin.reflect.KClass
 
 @Composable
@@ -119,252 +103,27 @@ fun TaskCreateSheet(
             TaskCreateForm(
                 targetClass = target,
                 date = date,
-                onCreate = {
+                onDialogClose = {
                     if (shouldCloseOnSubmit) {
                         onClose()
                     }
                 }
             )
         }
+
+        Spacer(modifier = Modifier.size(16.dp))
     }
 }
 
 @Composable
 fun TaskCreateForm(
-    model: TaskViewModel = hiltViewModel(),
     date: LocalDateTime? = null,
     targetClass: KClass<out Task>,
-    onCreate: () -> Unit
+    onDialogClose: () -> Unit
 ) {
-    var title by remember { mutableStateOf("") }
-    var description by remember { mutableStateOf("") }
-    var duration by remember { mutableStateOf(Duration.ofMinutes(0)) }
-    var reminderTime by remember { mutableStateOf<Duration?>(null) }
-    var activity by remember { mutableStateOf(SportActivity.Walking) }
-    var distance by remember { mutableDoubleStateOf(0.0) }
-    var dateTime by remember { mutableStateOf(date ?: LocalDateTime.now()) }
-    var editingTitle by remember { mutableStateOf("") }
-    var editingDescription by remember { mutableStateOf("") }
-    var editingDuration by remember { mutableStateOf(Duration.ofMinutes(0)) }
-    var editingReminderTime by remember { mutableStateOf(reminderTime) }
-    val editingHour = rememberPickerState(dateTime.hour)
-    val editingMinute = rememberPickerState(dateTime.minute)
-
-    val descriptionLabel = when (targetClass) {
-        MealTask::class -> "Recipe"
-        else -> "Description"
-    }
-
-    val isFormValid by remember(targetClass) {
-        derivedStateOf {
-            title.isNotEmpty()
-        }
-    }
-
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(MaterialTheme.shapes.medium)
-            .background(MaterialTheme.colorScheme.surfaceContainer)
-            .padding(8.dp)
-            .verticalScroll(rememberScrollState()),
-        verticalArrangement = Arrangement.spacedBy(16.dp)
-    ) {
-        EditableInfoItem(
-            dialogContent = {
-                OutlinedTextField(
-                    label = { Text("Title") },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 16.dp),
-                    onValueChange = { newText ->
-                        editingTitle = newText
-                    },
-                    value = editingTitle
-                )
-            },
-            dialogTitle = { Text("Editing title") },
-            label = "Title",
-            onConfirm = { title = editingTitle },
-            onDismiss = { editingTitle = title },
-            value = title
-        )
-
-        EditableInfoItem(
-            dialogContent = {
-                OutlinedTextField(
-                    label = { Text(descriptionLabel) },
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(bottom = 16.dp),
-                    onValueChange = { newText ->
-                        editingDescription = newText
-                    },
-                    value = editingDescription
-                )
-            },
-            dialogTitle = { Text("Editing $descriptionLabel") },
-            label = descriptionLabel,
-            onConfirm = { description = editingDescription },
-            onDismiss = { editingDescription = description },
-            value = description
-        )
-
-        if (targetClass == SportTask::class) {
-            TaskEditFieldsSport(
-                onActivityChange = { newActivity ->
-                    if (newActivity != null) {
-                        activity = newActivity
-                    }
-                },
-                onDistanceChange = { newDistance ->
-                    distance = newDistance
-                },
-                onDurationChange = { newDuration ->
-                    duration = newDuration
-                }
-            )
-        } else {
-            EditableInfoItem(
-                dialogContent = {
-                    Column {
-                        val initial = remember(editingDuration) {
-                            editingDuration
-                                ?.toMinutes()
-                                ?.toFloat()
-                                ?: 0f
-                        }
-
-                        Picker(
-                            items = (0..300 step 5).toList(),
-                            label = { "$it minutes" },
-                            onChange = { editingDuration = Duration.ofMinutes(it.toLong()) },
-                            startIndex = initial.toInt() / 5,
-                            state = rememberPickerState(initialValue = initial)
-                        )
-                    }
-                },
-                dialogTitle = { Text("Editing duration") },
-                label = "Duration",
-                onConfirm = { duration = editingDuration },
-                onDismiss = { editingDuration = duration },
-                value = "${duration?.toMinutes()} minutes"
-            )
-        }
-
-        EditableInfoItem(
-            dialogContent = {
-                PickerTime(
-                    selectedHour = editingHour,
-                    selectedMinute = editingMinute,
-                    onChange = { hour, minute ->
-                        editingHour.value = hour
-                        editingMinute.value = minute
-                    }
-                )
-            },
-            dialogTitle = { Text("Editing scheduled at") },
-            label = "Scheduled at",
-            onConfirm = {
-                dateTime = dateTime
-                    .withHour(editingHour.value)
-                    .withMinute(editingMinute.value)
-            },
-            onDismiss = {
-                editingHour.value = dateTime.hour
-                editingMinute.value = dateTime.minute
-            },
-            value = if (activity.supportsDistanceMetrics) {
-                dateTime.format(DateTimeFormatter.ofPattern("HH:mm"))
-            } else {
-                "${dateTime.format(DateTimeFormatter.ofPattern("HH:mm"))} - " +
-                        (dateTime.plus(duration)).format(DateTimeFormatter.ofPattern("HH:mm"))
-            }
-        )
-
-        EditableDateItem(
-            label = "Date",
-            value = dateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd, EEEE")),
-            onDateSelected = { selectedDate ->
-                dateTime = dateTime
-                    .withYear(selectedDate.year)
-                    .withMonth(selectedDate.monthValue)
-                    .withDayOfMonth(selectedDate.dayOfMonth)
-            }
-        )
-
-        EditableInfoItem(
-            dialogContent = {
-                Column {
-                    val initial = remember(editingReminderTime) {
-                        editingReminderTime
-                            ?.toMinutes()
-                            ?.toFloat()
-                            ?: 0f
-                    }
-
-                    Picker(
-                        items = (0..120 step 5).toList(),
-                        label = { "$it minutes" },
-                        onChange = { editingReminderTime = Duration.ofMinutes(it.toLong()) },
-                        startIndex = initial.toInt() / 5,
-                        state = rememberPickerState(initialValue = initial)
-                    )
-                }
-            },
-            dialogTitle = { Text("Editing reminder time") },
-            label = "Reminder Time",
-            onConfirm = { reminderTime = editingReminderTime },
-            onDismiss = { editingReminderTime = reminderTime },
-            value = if (reminderTime != null)
-                "${reminderTime?.toMinutes()} ${
-                    if (reminderTime
-                            ?.toMinutes()
-                            ?.toInt() == 1
-                    ) "minute" else "minutes"
-                } before task" else ""
-        )
-
-        Button(
-            onClick = {
-                when (targetClass) {
-                    SportTask::class -> model.create(
-                        date = dateTime.toLocalDate(),
-                        activity = activity,
-                        description = description,
-                        distance = distance,
-                        duration = duration,
-                        reminderTime = reminderTime,
-                        time = dateTime.toLocalTime(),
-                        title = title
-                    )
-
-                    MealTask::class -> model.create(
-                        date = dateTime.toLocalDate(),
-                        description = "",
-                        duration = duration,
-                        reminderTime = reminderTime,
-                        recipe = description,
-                        time = dateTime.toLocalTime(),
-                        title = title
-                    )
-
-                    else -> model.create(
-                        date = dateTime.toLocalDate(),
-                        description = description,
-                        duration = duration,
-                        reminderTime = reminderTime,
-                        time = dateTime.toLocalTime(),
-                        title = title
-                    )
-                }
-
-                onCreate()
-            },
-            enabled = isFormValid,
-            modifier = Modifier.align(Alignment.End)
-        ) {
-            Text("Create")
-        }
-    }
+    TaskCommonForm(
+        date = date,
+        targetClass = targetClass,
+        onDialogClose = onDialogClose
+    )
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
@@ -100,10 +100,10 @@ fun TaskCreateSheet(
 
             Spacer(modifier = Modifier.size(8.dp))
 
-            TaskCreateForm(
-                targetClass = target,
+            TaskCommonForm(
                 date = date,
-                onDialogClose = {
+                targetClass = target,
+                onClose = {
                     if (shouldCloseOnSubmit) {
                         onClose()
                     }
@@ -113,17 +113,4 @@ fun TaskCreateSheet(
 
         Spacer(modifier = Modifier.size(16.dp))
     }
-}
-
-@Composable
-fun TaskCreateForm(
-    date: LocalDateTime? = null,
-    targetClass: KClass<out Task>,
-    onDialogClose: () -> Unit
-) {
-    TaskCommonForm(
-        date = date,
-        targetClass = targetClass,
-        onDialogClose = onDialogClose
-    )
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsEdit.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsEdit.kt
@@ -15,29 +15,18 @@ import com.pvp.app.model.Task
 @Composable
 fun TaskEditSheet(
     task: Task,
-    onDialogClose: () -> Unit
+    onClose: () -> Unit
 ) {
 
     ModalBottomSheet(
-        onDismissRequest = onDialogClose,
+        onDismissRequest = onClose,
         sheetState = rememberModalBottomSheetState(true)
     ) {
-        TaskEditForm(
+        TaskCommonForm(
             task = task,
-            onDialogClose = onDialogClose
+            onClose = onClose
         )
 
         Spacer(modifier = Modifier.size(16.dp))
     }
-}
-
-@Composable
-fun TaskEditForm(
-    task: Task,
-    onDialogClose: () -> Unit
-) {
-    TaskCommonForm(
-        task = task,
-        onDialogClose = onDialogClose
-    )
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsEdit.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsEdit.kt
@@ -2,310 +2,42 @@
 
 package com.pvp.app.ui.screen.calendar
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Delete
-import androidx.compose.material3.ButtonDefaults
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
-import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
-import com.pvp.app.model.MealTask
-import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
-import com.pvp.app.ui.common.Button
-import com.pvp.app.ui.common.ButtonConfirm
-import com.pvp.app.ui.common.EditableDateItem
-import com.pvp.app.ui.common.EditableInfoItem
-import com.pvp.app.ui.common.Picker
-import com.pvp.app.ui.common.PickerState.Companion.rememberPickerState
-import com.pvp.app.ui.common.PickerTime
-import java.time.Duration
-import java.time.LocalTime
-import java.time.format.DateTimeFormatter
 
 @Composable
 fun TaskEditSheet(
     task: Task,
-    onDialogClose: () -> Unit,
-    model: TaskViewModel = hiltViewModel()
+    onDialogClose: () -> Unit
 ) {
-    var title by remember { mutableStateOf(task.title) }
-    var description by remember { mutableStateOf(task.description) }
-    var duration by remember { mutableStateOf(task.duration) }
-    var date by remember { mutableStateOf(task.date) }
-    var activity by remember { mutableStateOf((task as? SportTask)?.activity) }
-    var distance by remember { mutableStateOf((task as? SportTask)?.distance) }
-    var tempTitle by remember { mutableStateOf(title) }
-    var tempDescription by remember { mutableStateOf(description) }
-    var tempDuration by remember { mutableStateOf(duration) }
-    var time by remember { mutableStateOf(task.time ?: LocalTime.MIN) }
-    val tempHour = rememberPickerState(time.hour)
-    val tempMinute = rememberPickerState(time.minute)
-    var reminderTime by remember { mutableStateOf(task.reminderTime) }
-    var editingReminderTime by remember { mutableStateOf(reminderTime) }
-    val descriptionLabel = when (task::class) {
-        MealTask::class -> "Recipe"
-        else -> "Description"
-    }
 
     ModalBottomSheet(
         onDismissRequest = onDialogClose,
         sheetState = rememberModalBottomSheetState(true)
     ) {
-        Column(
-            modifier = Modifier
-                .background(MaterialTheme.colorScheme.surfaceContainer)
-                .verticalScroll(rememberScrollState())
-                .padding(8.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
-        ) {
-            EditableInfoItem(
-                dialogContent = {
-                    OutlinedTextField(
-                        label = { Text("Title") },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 16.dp),
-                        onValueChange = { newText ->
-                            tempTitle = newText
-                        },
-                        value = tempTitle
-                    )
-                },
-                dialogTitle = { Text("Editing title") },
-                label = "Title",
-                onConfirm = { title = tempTitle },
-                onDismiss = { tempTitle = title },
-                value = title
-            )
+        TaskEditForm(
+            task = task,
+            onDialogClose = onDialogClose
+        )
 
-            EditableInfoItem(
-                dialogContent = {
-                    OutlinedTextField(
-                        label = { Text(descriptionLabel) },
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 16.dp),
-                        onValueChange = { newText ->
-                            tempDescription = newText
-                        },
-                        value = tempDescription ?: ""
-                    )
-                },
-                dialogTitle = { Text("Editing $descriptionLabel") },
-                label = descriptionLabel,
-                onConfirm = { description = tempDescription },
-                onDismiss = { tempDescription = description },
-                value = description ?: ""
-            )
-
-            if (task is SportTask) {
-                TaskEditFieldsSport(
-                    task = task,
-                    onActivityChange = { newActivity ->
-                        activity = newActivity
-                    },
-                    onDistanceChange = { newDistance ->
-                        distance = newDistance
-                    },
-                    onDurationChange = { newDuration ->
-                        duration = newDuration
-                    }
-                )
-            } else {
-                EditableInfoItem(
-                    dialogContent = {
-                        Column {
-                            val initial = remember(tempDuration) {
-                                tempDuration
-                                    ?.toMinutes()
-                                    ?.toFloat()
-                                    ?: 0f
-                            }
-
-                            Picker(
-                                items = (0..300 step 5).toList(),
-                                label = { "$it minutes" },
-                                onChange = { tempDuration = Duration.ofMinutes(it.toLong()) },
-                                startIndex = initial.toInt() / 5,
-                                state = rememberPickerState(initialValue = initial)
-                            )
-                        }
-                    },
-                    dialogTitle = { Text("Editing duration") },
-                    label = "Duration",
-                    onConfirm = { duration = tempDuration },
-                    onDismiss = { tempDuration = duration },
-                    value = "${duration?.toMinutes()} minutes"
-                )
-            }
-
-            EditableInfoItem(
-                dialogContent = {
-                    PickerTime(
-                        selectedHour = tempHour,
-                        selectedMinute = tempMinute,
-                        onChange = { hour, minute ->
-                            tempHour.value = hour
-                            tempMinute.value = minute
-                        }
-                    )
-                },
-                dialogTitle = { Text("Editing scheduled at") },
-                label = "Scheduled at",
-                onConfirm = {
-                    time = time
-                        .withHour(tempHour.value)
-                        .withMinute(tempMinute.value)
-                },
-                onDismiss = {
-                    tempHour.value = time.hour
-                    tempMinute.value = time.minute
-                },
-                value = if (task is SportTask && activity!!.supportsDistanceMetrics) {
-                    time.format(DateTimeFormatter.ofPattern("HH:mm"))
-                } else {
-                    "${time.format(DateTimeFormatter.ofPattern("HH:mm"))} - " +
-                            (time.plus(duration)).format(DateTimeFormatter.ofPattern("HH:mm"))
-                }
-            )
-
-            EditableDateItem(
-                label = "Date",
-                value = date.format(DateTimeFormatter.ofPattern("yyyy-MM-dd, EEEE")),
-                onDateSelected = { selectedDate ->
-                    date = date
-                        .withYear(selectedDate.year)
-                        .withMonth(selectedDate.monthValue)
-                        .withDayOfMonth(selectedDate.dayOfMonth)
-                }
-            )
-
-            EditableInfoItem(
-                dialogContent = {
-                    Column {
-                        val initial = remember(editingReminderTime) {
-                            editingReminderTime
-                                ?.toMinutes()
-                                ?.toFloat()
-                                ?: 0f
-                        }
-
-                        Picker(
-                            items = (0..120 step 5).toList(),
-                            label = { "$it minutes" },
-                            onChange = { editingReminderTime = Duration.ofMinutes(it.toLong()) },
-                            startIndex = initial.toInt() / 5,
-                            state = rememberPickerState(initialValue = initial)
-                        )
-                    }
-                },
-                dialogTitle = { Text("Editing reminder time") },
-                label = "Reminder Time",
-                onConfirm = { reminderTime = editingReminderTime },
-                onDismiss = { editingReminderTime = reminderTime },
-                value = if (reminderTime != null)
-                    "${reminderTime?.toMinutes()} ${
-                        if (reminderTime
-                                ?.toMinutes()
-                                ?.toInt() == 1
-                        ) "minute" else "minutes"
-                    } before task" else ""
-            )
-
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(
-                        horizontal = 24.dp,
-                        vertical = 15.dp
-                    ),
-                horizontalArrangement = Arrangement.SpaceBetween
-            ) {
-                ButtonConfirm(
-                    border = BorderStroke(
-                        1.dp,
-                        Color.Red
-                    ),
-                    colors = ButtonDefaults.outlinedButtonColors(contentColor = Color.Red),
-                    content = {
-                        Row(verticalAlignment = Alignment.CenterVertically) {
-                            Icon(
-                                contentDescription = "Delete task icon",
-                                imageVector = Icons.Outlined.Delete
-                            )
-
-                            Text(
-                                style = MaterialTheme.typography.titleSmall,
-                                text = "Delete"
-                            )
-                        }
-                    },
-                    confirmationButtonContent = { Text("Delete") },
-                    confirmationDescription = { Text("If the task is deleted, it cannot be recovered") },
-                    confirmationTitle = { Text("Are you sure you want to delete this task?") },
-                    onConfirm = {
-                        model.remove(task)
-
-                        onDialogClose()
-                    },
-                    shape = MaterialTheme.shapes.extraLarge
-                )
-
-                Button(
-                    onClick = {
-                        model.update(
-                            { task ->
-                                task.title = title
-                                task.description = description
-                                task.duration = duration
-                                task.reminderTime = reminderTime
-                                task.date = date
-                                task.time = time
-
-                                when (task) {
-                                    is SportTask -> {
-                                        task.activity = activity!!
-                                        task.distance = distance
-                                    }
-
-                                    is MealTask -> {
-                                        task.recipe = description ?: ""
-                                        task.description = ""
-                                    }
-                                }
-                            },
-                            task
-                        )
-
-                        onDialogClose()
-                    }
-                ) {
-                    Text("Save")
-                }
-            }
-        }
+        Spacer(modifier = Modifier.size(16.dp))
     }
+}
+
+@Composable
+fun TaskEditForm(
+    task: Task,
+    onDialogClose: () -> Unit
+) {
+    TaskCommonForm(
+        task = task,
+        onDialogClose = onDialogClose
+    )
 }

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskViewModel.kt
@@ -36,6 +36,9 @@ class TaskViewModel @Inject constructor(
 ) : ViewModel() {
 
     val rangeKilometers = configuration.rangeKilometers
+    val rangeMeters = configuration.rangeMeters
+    val rangeReminderTime = configuration.rangeReminderMinutes
+    val rangeDuration = configuration.rangeDuration
 
     private val state = settingService
         .get(Setting.Notifications.ReminderBeforeTaskMinutes)

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/Filters.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/Filters.kt
@@ -47,7 +47,6 @@ fun FiltersItem(
     filtersType: String,
     title: String,
     selectedFilters: List<String>,
-    isSelected: Boolean? = null,
     dialogTitle: @Composable () -> Unit,
     dialogContent: @Composable () -> Unit,
     onConfirmClick: () -> Unit,
@@ -105,8 +104,8 @@ fun FiltersItem(
 
             FiltersBox(
                 filters = selectedFilters,
-                isSelected = isSelected,
-                title = filtersType
+                title = filtersType,
+                cardsClickable = false
             )
         }
     }
@@ -119,7 +118,9 @@ fun FiltersBox(
     filters: List<String>,
     isSelected: Boolean? = null,
     onClick: (String) -> Unit = {},
-    title: String? = null
+    title: String? = null,
+    emptyBoxText: String? = null,
+    cardsClickable: Boolean = true
 ) {
     Box(
         modifier = Modifier
@@ -139,7 +140,8 @@ fun FiltersBox(
 
             if (filters.isEmpty()) {
                 Text(
-                    text = if (isSelected == false) "No other $title" else "No $title selected",
+                    text = emptyBoxText
+                        ?: if (isSelected == false) "No other $title" else "No $title selected",
                     style = TextStyle(
                         fontSize = 15.sp,
                         fontStyle = FontStyle.Italic
@@ -162,8 +164,12 @@ fun FiltersBox(
                                 )
                         ) {
                             Card(
+                                enabled = cardsClickable,
                                 colors = CardDefaults.cardColors(
                                     containerColor = MaterialTheme.colorScheme.primary,
+                                    contentColor = MaterialTheme.colorScheme.onPrimary,
+                                    disabledContainerColor = MaterialTheme.colorScheme.primary,
+                                    disabledContentColor = MaterialTheme.colorScheme.onPrimary
                                 ),
                                 elevation = CardDefaults.cardElevation(
                                     defaultElevation = 8.dp
@@ -174,7 +180,7 @@ fun FiltersBox(
                                 ),
                                 onClick = {
                                     onClick(filter)
-                                }
+                                },
                             ) {
                                 Text(
                                     modifier = Modifier

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileViewModel.kt
@@ -37,6 +37,9 @@ class ProfileViewModel @Inject constructor(
 
     private val _state: MutableStateFlow<ProfileState> = MutableStateFlow(ProfileState())
     val state = _state.asStateFlow()
+    val rangeMass = configuration.rangeMass
+    val rangeHeight = configuration.rangeHeight
+    val intervalUsernameLength = configuration.intervalUsernameLength
 
     init {
         collectStateChanges()
@@ -84,10 +87,6 @@ class ProfileViewModel @Inject constructor(
 
             userService.merge(user)
         }
-    }
-
-    fun <T> fromConfiguration(function: (Configuration) -> T): T {
-        return function(configuration)
     }
 }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
@@ -85,7 +85,7 @@ private fun SettingNotificationReminderMinutes(
                     items = range,
                     label = { "$it minutes" },
                     modifier = Modifier.padding(top = 16.dp),
-                    startIndex = minutes - 1,
+                    startIndex = minutes / 5,
                     state = state
                 )
             }

--- a/app/src/main/java/com/pvp/app/worker/TaskNotificationWorker.kt
+++ b/app/src/main/java/com/pvp/app/worker/TaskNotificationWorker.kt
@@ -38,14 +38,8 @@ class TaskNotificationWorker @AssistedInject constructor(
                 notificationService
                     .getNotificationForTask(task)
                     ?.let { notification ->
-                        val reminderDateTime = task.date
-                            .atTime(task.time)
-                            .minusMinutes(task.reminderTime!!.toMinutes())
-
-                        notificationService.post(
-                            notification = notification,
-                            dateTime = reminderDateTime
-                        )
+                        notificationService.cancel(notification)
+                        notificationService.post(notification)
                     }
             }
 


### PR DESCRIPTION
# Changes:
- Refactored/simplified Task Create/Edit Forms
  - Both forms now use the same method to avoid repeating code.
  - Introduced new methods like EditableTextItem, EditablePickerItem, EditableTimeItem, EditableDistanceItem, etc to reduce code repetition, improve readability and cleanness of the code by reducing the number of parameters and eliminating the need of separate temporary variables for editing.
  - Empty or null values now don't render a Text component, making the item boxes smaller.
  
# Other Fixes:
- Added a Spacer at the bottom of the Task Create/Edit forms to prevent overlap between phone navigation buttons and the app's buttons.
- Included rangeDuration and rangeMeters in Configuration for consistency across the entire configuration system.
- Ensured that configurations are utilized in all relevant places to maintain synchronization.
- Adjusted tooltip icon size to eliminate unnecessary whitespace usage.
- Changed DatePicker dialog to default to date picking mode instead of date input mode for quicker access.
- Corrected text for empty weekly activities box in the profile screen (changed from "No weekly activities selected" to "No weekly activities have been assigned yet").
- Updated mass and height editing in the profile screen to use pickers instead of the previous text input method, aligning with the consistency of the survey screen.
- Disabled clickability of cards in the profile screen (previously, they triggered a "clicked" animation, which is unnecessary as they shouldn't be clickable).