### PR TITLE
PVP-258 Fixed crashing when trying to access Health Connect permissions

### DIFF
--- a/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.health.connect.HealthConnectManager
 import android.os.Build
+import androidx.annotation.RequiresApi
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -291,22 +292,11 @@ private fun SettingHealthConnectPermissions(context: Context) {
             )
             .fillMaxWidth(),
         onClick = {
-            val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-                Intent(HealthConnectManager.ACTION_MANAGE_HEALTH_PERMISSIONS)
-                    .putExtra(
-                        Intent.EXTRA_PACKAGE_NAME,
-                        context.packageName
-                    )
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                permissionsPostUpsideDownCake(context)
             } else {
-                Intent(
-                    HealthConnectClient.ACTION_HEALTH_CONNECT_SETTINGS
-                )
+                permissionsPreUpsideDownCake(context)
             }
-            startActivity(
-                context,
-                intent,
-                null
-            )
         },
         shape = MaterialTheme.shapes.medium
     ) {
@@ -542,4 +532,31 @@ fun <T> SettingCard(
             }
         }
     }
+}
+
+@RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
+private fun permissionsPostUpsideDownCake(context: Context) {
+    // On some phones even on Android 14 (API Level 14)
+    // Intent of ACTION_MANAGE_HEALTH_PERMISSIONS causes an exception
+    try {
+        startActivity(
+            context,
+            Intent(HealthConnectManager.ACTION_MANAGE_HEALTH_PERMISSIONS)
+                .putExtra(
+                    Intent.EXTRA_PACKAGE_NAME,
+                    context.packageName
+                ),
+            null
+        )
+    } catch (e: Exception) {
+        permissionsPreUpsideDownCake(context)
+    }
+}
+
+private fun permissionsPreUpsideDownCake(context: Context) {
+    startActivity(
+        context,
+        Intent(HealthConnectClient.ACTION_HEALTH_CONNECT_SETTINGS),
+        null
+    )
 }


### PR DESCRIPTION
When trying to access Health Connect permissions using the method for  >= Android 14 (Upside Down Cake) that directly opens Health Connect settings for specified app, causes crashing on some phones (works great on emulator).

Added a quick fix that for phones  >= Android 14 that tries to launch permissions using the newer method first, if that fails - uses the old method - opens Health Connect main page.

Phones with android versions < Android 14 automatically use the older method.