### PR TITLE
PVP-165 Add meals API; Rework meal task models

### DIFF
--- a/app/src/main/java/com/pvp/app/Application.kt
+++ b/app/src/main/java/com/pvp/app/Application.kt
@@ -53,42 +53,21 @@ class Application : Application(), Configuration.Provider, ImageLoaderFactory {
     override fun onCreate() {
         super.onCreate()
 
-        val prefs = getSharedPreferences(
-            "FirstInstall",
-            Context.MODE_PRIVATE
-        )
-
-        if (!prefs.getBoolean(
-                "SetupComplete",
-                false
-            )
-        ) {
-            createDailyTaskWorker()
-
-            createDrinkReminderWorker()
-
-            createNotificationChannels()
-
-            createTaskPointsDeductionWorker()
-
-            createTaskNotificationWorker()
-
-            createWeeklyActivitiesWorker()
-
-            prefs
-                .edit()
-                .putBoolean(
-                    "SetupComplete",
-                    true
-                )
-                .apply()
-        }
-
-        // Should be left out to ensure the TaskAutocompleteService is persisted
-        // as a running foreground service
         createAutocompleteWorker()
 
+        createDailyTaskWorker()
+
+        createDrinkReminderWorker()
+
         createGoalMotivationWorker()
+
+        createNotificationChannels()
+
+        createTaskNotificationWorker()
+
+        createTaskPointsDeductionWorker()
+
+        createWeeklyActivitiesWorker()
     }
 
     fun createActivityWorker() {

--- a/app/src/main/java/com/pvp/app/api/MealService.kt
+++ b/app/src/main/java/com/pvp/app/api/MealService.kt
@@ -1,0 +1,38 @@
+package com.pvp.app.api
+
+import com.pvp.app.model.Meal
+import kotlinx.coroutines.flow.Flow
+
+interface MealService : DocumentsCollection {
+
+    override val identifier: String
+        get() = "meals"
+
+    /**
+     * @return a flow of all meals in the database.
+     */
+    suspend fun get(): Flow<List<Meal>>
+
+    /**
+     * @param query Query to search for.
+     *
+     * @return a flow of meals that match the given [query] in their name or ingredients.
+     */
+    suspend fun get(query: String): Flow<List<Meal>>
+
+    /**
+     * Merges the given [meal] into the database.
+     * If the meal does not exist, it will be created.
+     * If the meal already exists, it will be updated.
+     *
+     * @param meal Meal to merge.
+     */
+    suspend fun merge(meal: Meal)
+
+    /**
+     * Removes the given [meal] from the database.
+     *
+     * @param meal Meal to remove.
+     */
+    suspend fun remove(meal: Meal)
+}

--- a/app/src/main/java/com/pvp/app/api/TaskService.kt
+++ b/app/src/main/java/com/pvp/app/api/TaskService.kt
@@ -1,5 +1,8 @@
 package com.pvp.app.api
 
+import com.pvp.app.model.CustomMealTask
+import com.pvp.app.model.GeneralTask
+import com.pvp.app.model.Meal
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportActivity
 import com.pvp.app.model.SportTask
@@ -44,7 +47,7 @@ interface TaskService : DocumentsCollection {
         time: LocalTime? = null,
         title: String,
         userEmail: String
-    ): Task
+    ): GeneralTask
 
     /**
      * Creates a sport task in the database with the given parameters. Points are calculated
@@ -81,7 +84,6 @@ interface TaskService : DocumentsCollection {
      * automatically upon creation.
      *
      * @param date scheduled date
-     * @param description description
      * @param duration duration
      * @param reminderTime minutes before the task to send a reminder
      * @param recipe recipe of the meal
@@ -89,16 +91,39 @@ interface TaskService : DocumentsCollection {
      * @param title title
      * @param userEmail user email to create the task for
      *
-     * @return created meal task
+     * @return created custom meal task
      */
     suspend fun create(
         date: LocalDate,
-        description: String? = null,
         duration: Duration? = null,
         reminderTime: Duration? = null,
         recipe: String,
         time: LocalTime? = null,
         title: String,
+        userEmail: String
+    ): CustomMealTask
+
+    /**
+     * Creates a meal task in the database with the given parameters. Points are calculated
+     * automatically upon creation.
+     *
+     * @param date scheduled date
+     * @param duration duration
+     * @param meal meal
+     * @param reminderTime minutes before the task to send a reminder
+     * @param time scheduled time
+     * @param title title. If not provided, [Meal.name] should be used within implementation
+     * @param userEmail user email to create the task for
+     *
+     * @return created meal task
+     */
+    suspend fun create(
+        date: LocalDate,
+        duration: Duration? = null,
+        meal: Meal,
+        reminderTime: Duration? = null,
+        time: LocalTime? = null,
+        title: String? = null,
         userEmail: String
     ): MealTask
 

--- a/app/src/main/java/com/pvp/app/common/JsonUtil.kt
+++ b/app/src/main/java/com/pvp/app/common/JsonUtil.kt
@@ -1,6 +1,6 @@
 package com.pvp.app.common
 
-import com.pvp.app.model.MealTask
+import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
 import kotlinx.serialization.json.Json
@@ -11,34 +11,14 @@ import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.contentOrNull
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.modules.SerializersModule
-import kotlinx.serialization.modules.polymorphic
 
 object JsonUtil {
 
     /**
-     * JSON serializer with polymorphic support for [Task] subclasses [MealTask] and [SportTask]
+     * JSON serializer with polymorphic support for [Task] subclasses [CustomMealTask] and [SportTask]
      * and support for unknown keys by ignoring them
      */
-    val JSON = Json {
-        ignoreUnknownKeys = true
-
-        serializersModule = SerializersModule {
-            polymorphic(
-                Task::class,
-                Task.serializer()
-            ) {
-                subclass(
-                    MealTask::class,
-                    MealTask.serializer()
-                )
-                subclass(
-                    SportTask::class,
-                    SportTask.serializer()
-                )
-            }
-        }
-    }
+    val JSON = Json { ignoreUnknownKeys = true }
 
     /**
      * Converts any object to [JsonElement]

--- a/app/src/main/java/com/pvp/app/di/ServiceModule.kt
+++ b/app/src/main/java/com/pvp/app/di/ServiceModule.kt
@@ -17,6 +17,7 @@ import com.pvp.app.api.FriendService
 import com.pvp.app.api.GoalService
 import com.pvp.app.api.HealthConnectService
 import com.pvp.app.api.ImageService
+import com.pvp.app.api.MealService
 import com.pvp.app.api.NotificationService
 import com.pvp.app.api.PointService
 import com.pvp.app.api.RewardService
@@ -34,6 +35,7 @@ import com.pvp.app.service.FriendServiceImpl
 import com.pvp.app.service.GoalServiceImpl
 import com.pvp.app.service.HealthConnectServiceImpl
 import com.pvp.app.service.ImageServiceImpl
+import com.pvp.app.service.MealServiceImpl
 import com.pvp.app.service.NotificationServiceImpl
 import com.pvp.app.service.PointServiceImpl
 import com.pvp.app.service.RewardServiceImpl
@@ -92,6 +94,10 @@ interface ServiceBindingsModule {
     @Binds
     @Singleton
     fun bindImageService(service: ImageServiceImpl): ImageService
+
+    @Binds
+    @Singleton
+    fun bindMealService(service: MealServiceImpl): MealService
 
     @Binds
     @Singleton

--- a/app/src/main/java/com/pvp/app/model/Meal.kt
+++ b/app/src/main/java/com/pvp/app/model/Meal.kt
@@ -1,0 +1,70 @@
+@file:OptIn(ExperimentalSerializationApi::class)
+
+package com.pvp.app.model
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
+
+@Serializable
+data class CaloricBreakdown(
+    val percentCarbs: Double = 0.0,
+    val percentFat: Double = 0.0,
+    val percentProtein: Double = 0.0
+)
+
+@Serializable
+data class Instructions(
+    val name: String = "",
+    val steps: List<Step> = emptyList()
+)
+
+@Serializable
+data class Length(
+    val number: Int = 0,
+    val unit: String = ""
+)
+
+@Serializable
+data class Meal(
+    val dishTypes: List<String> = emptyList(),
+    val diets: List<String> = emptyList(),
+    val id: String = "",
+    val image: String = "",
+    val nutrition: Nutrition = Nutrition(),
+    @JsonNames("instructions")
+    val recipe: List<Instructions> = emptyList(),
+    val readyInMinutes: Int = 0,
+    val servings: Int = 0,
+    @JsonNames("title")
+    val name: String = ""
+)
+
+@Serializable
+data class Nutrient(
+    val amount: Double = 0.0,
+    val name: String = "",
+    val percentOfDailyNeeds: Double = 0.0,
+    val unit: String = ""
+)
+
+@Serializable
+data class Nutrition(
+    val caloricBreakdown: CaloricBreakdown = CaloricBreakdown(),
+    val nutrients: List<Nutrient> = emptyList(),
+    val weightPerServing: WeightPerServing = WeightPerServing()
+)
+
+@Serializable
+data class Step(
+    val ingredients: List<String> = emptyList(),
+    val length: Length? = null,
+    val number: Int = 0,
+    val step: String = ""
+)
+
+@Serializable
+data class WeightPerServing(
+    val amount: Int = 0,
+    val unit: String = ""
+)

--- a/app/src/main/java/com/pvp/app/model/Tasks.kt
+++ b/app/src/main/java/com/pvp/app/model/Tasks.kt
@@ -1,5 +1,11 @@
 @file:OptIn(ExperimentalSerializationApi::class)
 
+@file:UseSerializers(
+    LocalDateSerializer::class,
+    LocalTimeSerializer::class,
+    DurationSerializer::class
+)
+
 package com.pvp.app.model
 
 import com.pvp.app.common.DurationSerializer
@@ -7,70 +13,79 @@ import com.pvp.app.common.LocalDateSerializer
 import com.pvp.app.common.LocalTimeSerializer
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.JsonNames
 import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalTime
 
 @Serializable
-class MealTask : Task {
-
-    var recipe: String
-
-    constructor(
-        date: LocalDate,
-        description: String? = null,
-        duration: Duration? = null,
-        reminderTime: Duration? = null,
-        id: String? = null,
-        isCompleted: Boolean,
-        points: Points,
-        recipe: String,
-        time: LocalTime? = null,
-        title: String,
-        userEmail: String
-    ) : super(
-        date,
-        description,
-        duration,
-        reminderTime,
-        id,
-        isCompleted,
-        points,
-        time,
-        title,
-        userEmail
-    ) {
-        this.recipe = recipe
-    }
+class CustomMealTask(
+    override val date: LocalDate,
+    override val duration: Duration? = null,
+    override val id: String? = null,
+    override val isCompleted: Boolean,
+    override val points: Points,
+    val recipe: String? = null,
+    override val reminderTime: Duration? = null,
+    override val time: LocalTime? = null,
+    override val title: String,
+    override val userEmail: String
+) : Task() {
 
     override fun toString(): String {
-        return "MealTask(recipe='$recipe') && " + super.toString()
+        return "CustomMealTask(recipe=$recipe) && " + super.toString()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+
+        if (javaClass != other?.javaClass) {
+            return false
+        }
+
+        if (!super.equals(other)) {
+            return false
+        }
+
+        other as CustomMealTask
+
+        return recipe == other.recipe
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+
+        result = 31 * result + (recipe?.hashCode() ?: 0)
+
+        return result
     }
 
     companion object {
 
         fun copy(
-            task: MealTask,
+            task: CustomMealTask,
             date: LocalDate = task.date,
-            description: String? = task.description,
             duration: Duration? = task.duration,
             id: String? = task.id,
             isCompleted: Boolean = task.isCompleted,
             points: Points = task.points,
-            recipe: String = task.recipe,
+            recipe: String? = task.recipe,
+            reminderTime: Duration? = task.reminderTime,
             time: LocalTime? = task.time,
             title: String = task.title,
             userEmail: String = task.userEmail
-        ): MealTask {
-            return MealTask(
+        ): CustomMealTask {
+            return CustomMealTask(
                 date = date,
-                description = description,
                 duration = duration,
                 id = id,
                 isCompleted = isCompleted,
                 points = points,
                 recipe = recipe,
+                reminderTime = reminderTime,
                 time = time,
                 title = title,
                 userEmail = userEmail
@@ -80,46 +95,96 @@ class MealTask : Task {
 }
 
 @Serializable
-class SportTask : Task {
-
-    var activity: SportActivity
-    var distance: Double? = null
-    var isDaily: Boolean = false
-
-    constructor(
-        activity: SportActivity = SportActivity.Other,
-        date: LocalDate,
-        description: String? = null,
-        distance: Double? = null,
-        duration: Duration? = null,
-        reminderTime: Duration? = null,
-        id: String? = null,
-        isCompleted: Boolean,
-        isDaily: Boolean,
-        points: Points,
-        time: LocalTime? = null,
-        title: String,
-        userEmail: String
-    ) : super(
-        date,
-        description,
-        duration,
-        reminderTime,
-        id,
-        isCompleted,
-        points,
-        time,
-        title,
-        userEmail
-    ) {
-        this.activity = activity
-        this.distance = distance
-        this.isDaily = isDaily
-    }
+class MealTask(
+    override val date: LocalDate,
+    override val duration: Duration? = null,
+    override val id: String? = null,
+    override val isCompleted: Boolean,
+    val mealId: String,
+    override val points: Points,
+    override val reminderTime: Duration? = null,
+    override val time: LocalTime? = null,
+    override val title: String,
+    override val userEmail: String
+) : Task() {
 
     override fun toString(): String {
-        return "SportTask(activity=$activity, distance=$distance, isDaily=$isDaily) && " + super.toString()
+        return "MealTask(mealId='$mealId') && " + super.toString()
     }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+
+        if (javaClass != other?.javaClass) {
+            return false
+        }
+
+        if (!super.equals(other)) {
+            return false
+        }
+
+        other as MealTask
+
+        return mealId == other.mealId
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+
+        result = 31 * result + mealId.hashCode()
+
+        return result
+    }
+
+    companion object {
+
+        fun copy(
+            task: MealTask,
+            date: LocalDate = task.date,
+            duration: Duration? = task.duration,
+            id: String? = task.id,
+            isCompleted: Boolean = task.isCompleted,
+            mealId: String = task.mealId,
+            points: Points = task.points,
+            reminderTime: Duration? = task.reminderTime,
+            time: LocalTime? = task.time,
+            title: String = task.title,
+            userEmail: String = task.userEmail
+        ): MealTask {
+            return MealTask(
+                date = date,
+                duration = duration,
+                id = id,
+                isCompleted = isCompleted,
+                mealId = mealId,
+                points = points,
+                reminderTime = reminderTime,
+                time = time,
+                title = title,
+                userEmail = userEmail
+            )
+        }
+    }
+}
+
+@Serializable
+class SportTask(
+    val activity: SportActivity = SportActivity.Other,
+    override val date: LocalDate,
+    val description: String? = null,
+    val distance: Double? = null,
+    override val duration: Duration? = null,
+    override val id: String? = null,
+    override val isCompleted: Boolean,
+    val isDaily: Boolean = false,
+    override val points: Points,
+    override val reminderTime: Duration? = null,
+    override val time: LocalTime? = null,
+    override val title: String,
+    override val userEmail: String
+) : Task() {
 
     companion object {
 
@@ -134,6 +199,7 @@ class SportTask : Task {
             isCompleted: Boolean = task.isCompleted,
             isDaily: Boolean = task.isDaily,
             points: Points = task.points,
+            reminderTime: Duration? = task.reminderTime,
             time: LocalTime? = task.time,
             title: String = task.title,
             userEmail: String = task.userEmail
@@ -148,6 +214,7 @@ class SportTask : Task {
                 isCompleted = isCompleted,
                 isDaily = isDaily,
                 points = points,
+                reminderTime = reminderTime,
                 time = time,
                 title = title,
                 userEmail = userEmail
@@ -157,26 +224,134 @@ class SportTask : Task {
 }
 
 @Serializable
-open class Task(
-    @JsonNames("scheduledAt")
-    @Serializable(LocalDateSerializer::class)
-    var date: LocalDate,
-    var description: String? = null,
-    @Serializable(DurationSerializer::class)
-    var duration: Duration? = null,
-    @Serializable(DurationSerializer::class)
-    var reminderTime: Duration? = null,
-    val id: String? = null,
-    var isCompleted: Boolean,
-    var points: Points,
-    @Serializable(LocalTimeSerializer::class)
-    var time: LocalTime? = null,
-    var title: String,
-    val userEmail: String
-) {
+class GeneralTask(
+    override val date: LocalDate,
+    val description: String?,
+    override val duration: Duration? = null,
+    override val id: String? = null,
+    override val isCompleted: Boolean,
+    override val points: Points,
+    override val reminderTime: Duration? = null,
+    override val time: LocalTime? = null,
+    override val title: String,
+    override val userEmail: String
+) : Task() {
 
     override fun toString(): String {
-        return "Task(date=$date, description=$description, duration=$duration, id=$id, isCompleted=$isCompleted, points=$points, time=$time, title='$title', userEmail='$userEmail')"
+        return "GeneralTask(description=$description) && " + super.toString()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+
+        if (javaClass != other?.javaClass) {
+            return false
+        }
+
+        if (!super.equals(other)) {
+            return false
+        }
+
+        other as GeneralTask
+
+        return description == other.description
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+
+        result = 31 * result + (description?.hashCode() ?: 0)
+
+        return result
+    }
+
+    companion object {
+
+        fun copy(
+            task: GeneralTask,
+            date: LocalDate = task.date,
+            description: String? = task.description,
+            duration: Duration? = task.duration,
+            id: String? = task.id,
+            isCompleted: Boolean = task.isCompleted,
+            points: Points = task.points,
+            reminderTime: Duration? = task.reminderTime,
+            time: LocalTime? = task.time,
+            title: String = task.title,
+            userEmail: String = task.userEmail
+        ): GeneralTask {
+            return GeneralTask(
+                date = date,
+                description = description,
+                duration = duration,
+                id = id,
+                isCompleted = isCompleted,
+                points = points,
+                reminderTime = reminderTime,
+                time = time,
+                title = title,
+                userEmail = userEmail
+            )
+        }
+    }
+}
+
+@Serializable
+abstract class Task {
+
+    @JsonNames("scheduledAt")
+    abstract val date: LocalDate
+
+    abstract val duration: Duration?
+    abstract val id: String?
+    abstract val isCompleted: Boolean
+    abstract val points: Points
+    abstract val reminderTime: Duration?
+    abstract val time: LocalTime?
+    abstract val title: String
+    abstract val userEmail: String
+
+    override fun toString(): String {
+        return "Task(date=$date, duration=$duration, id=$id, isCompleted=$isCompleted, points=$points, time=$time, title='$title', userEmail='$userEmail')"
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+
+        if (javaClass != other?.javaClass) {
+            return false
+        }
+
+        other as Task
+
+        return date == other.date &&
+                duration == other.duration &&
+                id == other.id &&
+                isCompleted == other.isCompleted &&
+                points == other.points &&
+                reminderTime == other.reminderTime &&
+                time == other.time &&
+                title == other.title &&
+                userEmail == other.userEmail
+    }
+
+    override fun hashCode(): Int {
+        var result = date.hashCode()
+
+        result = 31 * result + (duration?.hashCode() ?: 0)
+        result = 31 * result + (id?.hashCode() ?: 0)
+        result = 31 * result + isCompleted.hashCode()
+        result = 31 * result + points.hashCode()
+        result = 31 * result + (reminderTime?.hashCode() ?: 0)
+        result = 31 * result + (time?.hashCode() ?: 0)
+        result = 31 * result + title.hashCode()
+        result = 31 * result + userEmail.hashCode()
+
+        return result
     }
 
     companion object {
@@ -184,28 +359,70 @@ open class Task(
         fun copy(
             task: Task,
             date: LocalDate = task.date,
-            description: String? = task.description,
             duration: Duration? = task.duration,
-            reminderTime: Duration? = task.reminderTime,
             id: String? = task.id,
             isCompleted: Boolean = task.isCompleted,
             points: Points = task.points,
+            reminderTime: Duration? = task.reminderTime,
             time: LocalTime? = task.time,
             title: String = task.title,
             userEmail: String = task.userEmail
         ): Task {
-            return Task(
-                date = date,
-                description = description,
-                duration = duration,
-                reminderTime = reminderTime,
-                id = id,
-                isCompleted = isCompleted,
-                points = points,
-                time = time,
-                title = title,
-                userEmail = userEmail
-            )
+            return when (task) {
+                is CustomMealTask -> CustomMealTask.copy(
+                    task,
+                    date = date,
+                    duration = duration,
+                    id = id,
+                    isCompleted = isCompleted,
+                    points = points,
+                    reminderTime = reminderTime,
+                    time = time,
+                    title = title,
+                    userEmail = userEmail
+                )
+
+                is MealTask -> MealTask.copy(
+                    task,
+                    date = date,
+                    duration = duration,
+                    id = id,
+                    isCompleted = isCompleted,
+                    points = points,
+                    reminderTime = reminderTime,
+                    time = time,
+                    title = title,
+                    userEmail = userEmail
+                )
+
+                is SportTask -> SportTask.copy(
+                    task,
+                    date = date,
+                    duration = duration,
+                    id = id,
+                    isCompleted = isCompleted,
+                    points = points,
+                    reminderTime = reminderTime,
+                    time = time,
+                    title = title,
+                    userEmail = userEmail
+                )
+
+                is GeneralTask -> GeneralTask.copy(
+                    task,
+                    date = date,
+                    duration = duration,
+                    id = id,
+                    isCompleted = isCompleted,
+                    points = points,
+                    reminderTime = reminderTime,
+                    time = time,
+                    title = title,
+                    userEmail = userEmail
+                )
+
+                else -> error("Unsupported task type for copy operation")
+            }
         }
     }
 }

--- a/app/src/main/java/com/pvp/app/model/Tasks.kt
+++ b/app/src/main/java/com/pvp/app/model/Tasks.kt
@@ -186,6 +186,42 @@ class SportTask(
     override val userEmail: String
 ) : Task() {
 
+    override fun toString(): String {
+        return "SportTask(activity=$activity, description=$description, distance=$distance, isDaily=$isDaily) && " + super.toString()
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) {
+            return true
+        }
+
+        if (javaClass != other?.javaClass) {
+            return false
+        }
+
+        if (!super.equals(other)) {
+            return false
+        }
+
+        other as SportTask
+
+        return activity == other.activity &&
+                description == other.description &&
+                distance == other.distance &&
+                isDaily == other.isDaily
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+
+        result = 31 * result + activity.hashCode()
+        result = 31 * result + (description?.hashCode() ?: 0)
+        result = 31 * result + (distance?.hashCode() ?: 0)
+        result = 31 * result + isDaily.hashCode()
+
+        return result
+    }
+
     companion object {
 
         fun copy(

--- a/app/src/main/java/com/pvp/app/service/AutocompleteService.kt
+++ b/app/src/main/java/com/pvp/app/service/AutocompleteService.kt
@@ -94,9 +94,10 @@ class AutocompleteService : Service() {
                     }
 
                     false -> {
-                        task.isCompleted = true
-
-                        return@mapNotNull task
+                        return@mapNotNull SportTask.copy(
+                            task,
+                            isCompleted = true
+                        )
                     }
                 }
             }

--- a/app/src/main/java/com/pvp/app/service/MealServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/MealServiceImpl.kt
@@ -1,0 +1,81 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package com.pvp.app.service
+
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.snapshots
+import com.pvp.app.api.MealService
+import com.pvp.app.model.Meal
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.mapLatest
+import javax.inject.Inject
+
+class MealServiceImpl @Inject constructor(
+    private val database: FirebaseFirestore
+) : MealService {
+
+    override suspend fun get(): Flow<List<Meal>> {
+        return database
+            .collection(identifier)
+            .snapshots()
+            .mapLatest { snapshot ->
+                snapshot.documents.mapNotNull { document ->
+                    document.toObject(Meal::class.java)
+                }
+            }
+    }
+
+    override suspend fun get(query: String): Flow<List<Meal>> {
+        return database
+            .collection(identifier)
+            .whereEqualTo(
+                Meal::name.name,
+                query
+            )
+            .snapshots()
+            .mapLatest { snapshot ->
+                snapshot.documents.mapNotNull { document ->
+                    document.toObject(Meal::class.java)
+                }
+            }
+    }
+
+    override suspend fun merge(meal: Meal) {
+        database.runTransaction {
+            if (meal.id.isBlank()) {
+                val document = database
+                    .collection(identifier)
+                    .document()
+
+                val mealNew = meal.copy(id = document.id)
+
+                it.set(
+                    document,
+                    mealNew
+                )
+            } else {
+                it.set(
+                    database
+                        .collection(identifier)
+                        .document(meal.id),
+                    meal
+                )
+            }
+        }
+    }
+
+    override suspend fun remove(meal: Meal) {
+        if (meal.id.isBlank()) {
+            error("Meal id is empty, cannot remove meal from the database")
+        }
+
+        database.runTransaction {
+            it.delete(
+                database
+                    .collection(identifier)
+                    .document(meal.id)
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/pvp/app/service/PointServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/PointServiceImpl.kt
@@ -6,6 +6,7 @@ import com.pvp.app.api.Configuration
 import com.pvp.app.api.PointService
 import com.pvp.app.api.TaskService
 import com.pvp.app.api.UserService
+import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.Goal
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportTask
@@ -40,7 +41,7 @@ class PointServiceImpl @Inject constructor(
                 add(if (Random.nextFloat() <= 0.1) 2 else 1)
 
                 when (task) {
-                    is MealTask -> {
+                    is CustomMealTask, is MealTask -> {
                         task.duration
                             ?.toMinutes()
                             ?.let {
@@ -190,8 +191,8 @@ class PointServiceImpl @Inject constructor(
 
     private fun Task.markExpired(): Task {
         return when (this) {
-            is MealTask -> {
-                MealTask.copy(
+            is CustomMealTask -> {
+                CustomMealTask.copy(
                     points = this.points.copy(
                         isExpired = true
                     ),

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/AnalysesOfDay.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/AnalysesOfDay.kt
@@ -28,10 +28,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -40,7 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.health.connect.client.PermissionController
 import androidx.hilt.navigation.compose.hiltViewModel
-import com.pvp.app.model.MealTask
+import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
 import java.time.LocalDate
@@ -200,7 +196,7 @@ private fun TasksOfDayCounterContainer(tasks: List<Task>) {
         TasksOfDayCounter(
             Icons.Outlined.Restaurant,
             tasks,
-            MealTask::class
+            CustomMealTask::class
         )
 
         TasksOfDayCounter(

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
@@ -30,11 +30,13 @@ import androidx.compose.ui.Alignment.Companion.CenterVertically
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.pvp.app.common.DurationUtil.asString
-import com.pvp.app.model.MealTask
+import com.pvp.app.model.CustomMealTask
+import com.pvp.app.model.GeneralTask
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
 import com.pvp.app.ui.common.InfoTooltip
@@ -92,7 +94,12 @@ fun TaskCard(
                         .align(CenterVertically),
                     onCheckedChange = {
                         model.update(
-                            { task -> task.isCompleted = it },
+                            { task ->
+                                Task.copy(
+                                    task,
+                                    isCompleted = it
+                                )
+                            },
                             task
                         )
 
@@ -120,7 +127,7 @@ fun TaskCard(
 
                     when (task) {
                         is SportTask -> TaskCardContentSport(task)
-                        is MealTask -> TaskCardContentMeal(task)
+                        is CustomMealTask -> TaskCardContentMeal(task)
                         else -> TaskCardContent(task)
                     }
                 }
@@ -138,7 +145,7 @@ fun TaskCard(
 }
 
 @Composable
-private fun TaskCardContentMeal(task: MealTask) {
+private fun TaskCardContentMeal(task: CustomMealTask) {
     task.duration?.let { duration ->
         Row(modifier = Modifier.padding(6.dp)) {
             Icon(
@@ -157,9 +164,11 @@ private fun TaskCardContentMeal(task: MealTask) {
     }
 
     Text(
+        maxLines = 2,
         modifier = Modifier
             .fillMaxWidth()
             .padding(start = 8.dp),
+        overflow = TextOverflow.Ellipsis,
         text = "Recipe: " + task.recipe,
         textAlign = TextAlign.Left
     )
@@ -167,7 +176,7 @@ private fun TaskCardContentMeal(task: MealTask) {
 
 @Composable
 private fun TaskCardContentSport(task: SportTask) {
-    if (task.distance != null && task.distance!! > 0) {
+    if (task.distance != null && task.distance > 0) {
         Row(modifier = Modifier.padding(6.dp)) {
             Icon(
                 contentDescription = "Distance",
@@ -193,7 +202,7 @@ private fun TaskCardContentSport(task: SportTask) {
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(start = 8.dp),
-                text = task.duration!!.asString(),
+                text = task.duration.asString(),
                 textAlign = TextAlign.Left
             )
         }
@@ -222,6 +231,22 @@ private fun TaskCardContentSport(task: SportTask) {
 
 @Composable
 private fun TaskCardContent(task: Task) {
+    val description = remember(task) {
+        when (task) {
+            is SportTask -> {
+                task.description
+            }
+
+            is GeneralTask -> {
+                task.description
+            }
+
+            else -> {
+                null
+            }
+        }
+    }
+
     task.duration?.let { duration ->
         Row(modifier = Modifier.padding(6.dp)) {
             Icon(
@@ -239,7 +264,7 @@ private fun TaskCardContent(task: Task) {
         }
     }
 
-    task.description?.let { description ->
+    if (description != null) {
         Text(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsCreate.kt
@@ -28,7 +28,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.dp
-import com.pvp.app.model.MealTask
+import com.pvp.app.model.CustomMealTask
+import com.pvp.app.model.GeneralTask
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
 import java.time.LocalDateTime
@@ -47,8 +48,8 @@ private fun ColumnScope.TaskTypeSelector(onSelect: (KClass<out Task>) -> Unit) {
         selectedTabIndex = selectedTabIndex
     ) {
         mapOf(
-            Task::class to "General",
-            MealTask::class to "Meal",
+            GeneralTask::class to "General",
+            CustomMealTask::class to "Meal",
             SportTask::class to "Sport"
         )
             .onEachIndexed { index, (taskClass, taskText) ->
@@ -90,7 +91,7 @@ fun TaskCreateSheet(
                 .background(MaterialTheme.colorScheme.surfaceContainer)
                 .padding(8.dp)
         ) {
-            var target by remember { mutableStateOf(Task::class as KClass<out Task>) }
+            var target by remember { mutableStateOf(GeneralTask::class as KClass<out Task>) }
 
             TaskTypeSelector { targetNew -> target = targetNew }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsEdit.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskFormsEdit.kt
@@ -17,7 +17,6 @@ fun TaskEditSheet(
     task: Task,
     onClose: () -> Unit
 ) {
-
     ModalBottomSheet(
         onDismissRequest = onClose,
         sheetState = rememberModalBottomSheetState(true)

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskViewModel.kt
@@ -7,7 +7,7 @@ import com.pvp.app.api.NotificationService
 import com.pvp.app.api.SettingService
 import com.pvp.app.api.TaskService
 import com.pvp.app.api.UserService
-import com.pvp.app.model.MealTask
+import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.Setting
 import com.pvp.app.model.SportActivity
 import com.pvp.app.model.SportTask
@@ -62,7 +62,6 @@ class TaskViewModel @Inject constructor(
      */
     fun create(
         date: LocalDate,
-        description: String? = null,
         duration: Duration? = null,
         reminderTime: Duration? = null,
         recipe: String,
@@ -76,7 +75,6 @@ class TaskViewModel @Inject constructor(
                     taskService
                         .create(
                             date,
-                            description,
                             duration,
                             reminderTime,
                             recipe,
@@ -165,7 +163,7 @@ class TaskViewModel @Inject constructor(
      */
     @Suppress("UNCHECKED_CAST")
     private fun <T : Task> resolve(
-        handle: (T) -> Unit,
+        handle: (T) -> T,
         task: T
     ): Pair<T, Boolean> {
         val taskNew: T
@@ -173,9 +171,7 @@ class TaskViewModel @Inject constructor(
 
         when (task) {
             is SportTask -> {
-                taskNew = SportTask.copy(task) as T
-
-                handle(taskNew)
+                taskNew = handle(task)
 
                 with(taskNew as SportTask) {
                     update = activity != task.activity ||
@@ -184,18 +180,14 @@ class TaskViewModel @Inject constructor(
                 }
             }
 
-            is MealTask -> {
-                taskNew = MealTask.copy(task) as T
-
-                handle(taskNew)
+            is CustomMealTask -> {
+                taskNew = handle(task)
 
                 update = taskNew.duration != task.duration
             }
 
             else -> {
-                taskNew = Task.copy(task) as T
-
-                handle(taskNew)
+                taskNew = handle(task)
 
                 update = false
             }
@@ -214,7 +206,7 @@ class TaskViewModel @Inject constructor(
      * @param task Task to update
      */
     fun <T : Task> update(
-        handle: (T) -> Unit,
+        handle: (T) -> T,
         task: T
     ) {
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TasksOfDay.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TasksOfDay.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
-import com.pvp.app.model.MealTask
+import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
 import java.util.Locale
@@ -139,8 +139,8 @@ private fun filterTasks(
     return when (filter) {
         TaskFilter.Daily -> tasks.filter { it is SportTask && it.isDaily }
         TaskFilter.Sports -> tasks.filter { it is SportTask && !it.isDaily }
-        TaskFilter.Meal -> tasks.filterIsInstance<MealTask>()
-        TaskFilter.General -> tasks.filter { task -> task !is SportTask && task !is MealTask }
+        TaskFilter.Meal -> tasks.filterIsInstance<CustomMealTask>()
+        TaskFilter.General -> tasks.filter { task -> task !is SportTask && task !is CustomMealTask }
     }
 }
 


### PR DESCRIPTION
# Changes

- Added many models around Meal. Currently we hold this info
  - Name
  - Ready Time (how long to make, not really accurate)
  - Instructions (Recipe)
  - Nutrients (calories/fat/protein/carbs/...)
  - % of food being protein/fat/carbs
  - Type of meal (lunch/dinner/...)
- We are not going to use actual API, so most of the interface calls will have to be implemented by us. For now there are only a main ones, in next task it will be expanded
- Had to adjust many code parts around tasks, where type of task matters
  - Now we have 2 meal task types:
    - CustomMealTask is for user defined recipes to hold.
    - MealTask is for choosing our meal entries with their recipes.
  - Made Task be abstract and instead we now have GeneralTask type
    - Because there was no need to have `description` field in some tasks, however, general task should have it
- Added ~300 meals to the database around main ingredients (defined in the enum)
- Reverted workers being called only at first launch to make everything at least functional

While reviewing, please look if nothing could have broke. After small testing it seemed to work as intended, but _who knows_...