### PR TITLE
PVP 271

### DIFF
--- a/app/src/main/java/com/pvp/app/model/Decoration.kt
+++ b/app/src/main/java/com/pvp/app/model/Decoration.kt
@@ -13,6 +13,7 @@ data class Decoration(
 )
 
 enum class Type {
+    AVATAR_ACCESSORY,
     AVATAR_BODY,
     AVATAR_FACE,
     AVATAR_HANDS,
@@ -22,6 +23,7 @@ enum class Type {
 
     override fun toString(): String {
         return when (this) {
+            AVATAR_ACCESSORY -> "Accessory"
             AVATAR_BODY -> "Body"
             AVATAR_FACE -> "Face"
             AVATAR_HANDS -> "Hands"

--- a/app/src/main/java/com/pvp/app/service/DecorationServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/DecorationServiceImpl.kt
@@ -271,6 +271,7 @@ class DecorationServiceImpl @Inject constructor(
                     .thenBy { it.type == Type.AVATAR_BODY }
                     .thenBy { it.type == Type.AVATAR_LEGGINGS }
                     .thenBy { it.type == Type.AVATAR_HANDS }
+                    .thenBy { it.type == Type.AVATAR_ACCESSORY }
             )
         }
     }

--- a/app/src/main/java/com/pvp/app/service/DecorationServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/DecorationServiceImpl.kt
@@ -120,7 +120,11 @@ class DecorationServiceImpl @Inject constructor(
             .snapshots()
             .mapLatest { snapshot ->
                 snapshot.documents.mapNotNull { document ->
-                    document.toObject(Decoration::class.java)
+                    try {
+                        document.toObject(Decoration::class.java)
+                    } catch (e: Exception) {
+                        null
+                    }
                 }
             }
     }
@@ -130,7 +134,13 @@ class DecorationServiceImpl @Inject constructor(
             .collection(identifier)
             .document(id)
             .snapshots()
-            .mapLatest { snapshot -> snapshot.toObject(Decoration::class.java) }
+            .mapLatest { snapshot ->
+                try {
+                    snapshot.toObject(Decoration::class.java)
+                } catch (e: Exception) {
+                    null
+                }
+            }
             .filterNotNull()
     }
 


### PR DESCRIPTION
- Ensured app does not crash if it gets a decoration from database which is of type that is not implemented in the current app version
- Added decoration type 'accessory'. Currently a red balloon of that type is created

![image](https://github.com/PVP-K410/Calendar/assets/25864361/f46da651-a961-4b49-b5b4-6822b2913ed8)
