### PR TITLE
PVP-259 Add more sorting types in friends leaderboard

### DIFF
--- a/app/src/main/java/com/pvp/app/model/ActivityEntry.kt
+++ b/app/src/main/java/com/pvp/app/model/ActivityEntry.kt
@@ -9,6 +9,7 @@ data class ActivityEntry(
     var calories: Double = 0.0,
     @Contextual
     var date: Timestamp = Timestamp.now(),
+    var distance: Double = 0.0,
     val email: String = "",
     var id: String? = null,
     var steps: Long = 0

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
@@ -113,7 +113,7 @@ private fun ActivityInfo(
             ActivityRow(
                 icon = Icons.Outlined.Straighten,
                 contentDescription = "Distance",
-                text = "%.2f km".format(distance)
+                text = "%.2f km".format(distance / 1000)
             )
 
             HorizontalDivider(

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.FactCheck
 import androidx.compose.material.icons.outlined.LocalFireDepartment
+import androidx.compose.material.icons.outlined.Straighten
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -62,6 +63,8 @@ import java.time.format.DateTimeFormatter
 @Composable
 private fun ActivityInfo(
     calories: Double,
+    distance: Double,
+    goalsCompleted: Int,
     tasksCompleted: Int,
     steps: Long
 ) {
@@ -78,7 +81,7 @@ private fun ActivityInfo(
         Column(
             modifier = Modifier
                 .fillMaxSize()
-                .height(90.dp)
+                .height(120.dp)
                 .clip(MaterialTheme.shapes.small)
                 .padding(vertical = 4.dp),
             verticalArrangement = Arrangement.SpaceEvenly
@@ -108,9 +111,33 @@ private fun ActivityInfo(
             )
 
             ActivityRow(
+                icon = Icons.Outlined.Straighten,
+                contentDescription = "Distance",
+                text = "%.2f km".format(distance)
+            )
+
+            HorizontalDivider(
+                color = Color.Gray,
+                thickness = 1.dp,
+                modifier = Modifier.padding(horizontal = 14.dp)
+            )
+
+            ActivityRow(
                 icon = Icons.AutoMirrored.Outlined.FactCheck,
                 contentDescription = "tasks",
                 text = "$tasksCompleted sport tasks completed"
+            )
+
+            HorizontalDivider(
+                color = Color.Gray,
+                thickness = 1.dp,
+                modifier = Modifier.padding(horizontal = 14.dp)
+            )
+
+            ActivityRow(
+                icon = Icons.AutoMirrored.Outlined.FactCheck,
+                contentDescription = "goals",
+                text = "$goalsCompleted goals completed"
             )
         }
 
@@ -167,7 +194,9 @@ private fun AvatarBox(friend: FriendEntry) {
 private fun Content(
     calories: Double,
     details: Friends,
+    distance: Double,
     friends: List<FriendEntry>,
+    goals: Int,
     steps: Long,
     tasks: Int
 ) {
@@ -185,6 +214,8 @@ private fun Content(
     Column(horizontalAlignment = Alignment.CenterHorizontally) {
         ActivityInfo(
             calories,
+            distance,
+            goals,
             tasks,
             steps
         )
@@ -283,8 +314,6 @@ fun FriendScreen(
     val details = state.details
     val entry = state.entry
     val friends = state.friendsMutual
-    val steps = state.steps
-    val tasks = state.tasksCompleted
     val stateScroll = rememberScrollState()
 
     Column(
@@ -303,9 +332,11 @@ fun FriendScreen(
         Content(
             calories = calories,
             details = details,
+            distance = entry.distance,
             friends = friends,
-            steps = steps,
-            tasks = tasks
+            goals = entry.goalsCompleted,
+            steps = entry.steps,
+            tasks = entry.tasksCompleted
         )
 
         Spacer(modifier = Modifier.size(12.dp))

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/FriendsScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/FriendsScreen.kt
@@ -64,8 +64,12 @@ import com.pvp.app.ui.common.lighten
 import com.pvp.app.ui.router.Routes
 
 private enum class SortingType {
+    DISTANCE,
     EXPERIENCE,
-    POINTS
+    GOALS,
+    POINTS,
+    STEPS,
+    TASKS,
 }
 
 @Composable
@@ -97,8 +101,12 @@ fun FriendsScreen(
     ) {
         mutableStateOf(
             when (sortingType.value) {
+                SortingType.DISTANCE -> friends.sortedByDescending { it.distance }
                 SortingType.EXPERIENCE -> friends.sortedByDescending { it.user.experience }
+                SortingType.GOALS -> friends.sortedByDescending { it.goalsCompleted }
                 SortingType.POINTS -> friends.sortedByDescending { it.user.points }
+                SortingType.STEPS -> friends.sortedByDescending { it.steps }
+                SortingType.TASKS -> friends.sortedByDescending { it.tasksCompleted }
             }
         )
     }

--- a/app/src/main/java/com/pvp/app/ui/screen/friends/Models.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/friends/Models.kt
@@ -10,6 +10,10 @@ data class FriendEntry(
         1,
         1
     ),
+    val distance: Double = 0.0,
+    val goalsCompleted: Int = 0,
+    val steps: Long = 0L,
+    val tasksCompleted: Int = 0,
     val user: User = User()
 )
 
@@ -19,8 +23,6 @@ data class FriendState(
     val entry: FriendEntry = FriendEntry(),
     val friendsMutual: List<FriendEntry> = emptyList(),
     val state: FriendScreenState = FriendScreenState.Loading,
-    val steps: Long = 0L,
-    val tasksCompleted: Int = 0
 )
 
 sealed class FriendScreenState {

--- a/app/src/main/java/com/pvp/app/worker/ActivityWorker.kt
+++ b/app/src/main/java/com/pvp/app/worker/ActivityWorker.kt
@@ -117,6 +117,7 @@ class ActivityWorker @AssistedInject constructor(
 
         for (date in start.datesUntil(end.plusDays(1))) {
             val calories = getCalories(date)
+            val distance = getDistance(date)
             val steps = getSteps(date)
 
             val activity = activityService
@@ -130,6 +131,7 @@ class ActivityWorker @AssistedInject constructor(
                 activityService.merge(
                     ActivityEntry(
                         date = date.toTimestamp(),
+                        distance = distance,
                         calories = calories,
                         steps = steps,
                         email = email
@@ -139,6 +141,7 @@ class ActivityWorker @AssistedInject constructor(
                 activityService.merge(
                     activity.copy(
                         calories = calories,
+                        distance = distance,
                         steps = steps
                     )
                 )
@@ -154,6 +157,22 @@ class ActivityWorker @AssistedInject constructor(
             .toInstant()
 
         return healthConnectService.aggregateTotalCalories(
+            start,
+            end
+        )
+    }
+
+    private suspend fun getDistance(date: LocalDate): Double {
+        val end = date
+            .plusDays(1)
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant()
+
+        val start = date
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant()
+
+        return healthConnectService.aggregateDistance(
             start,
             end
         )


### PR DESCRIPTION
- Added distance tracking so that we can sort by weekly distance
- Distance, steps, tasks and goals were added to FriendEntry (steps and tasks were removed), so we can sort by these types in the leaderboard.
- Added display of distance and goals completed to the friend screen