### PR TITLE
PVP-264 Add google calendar synchronization

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -103,6 +103,7 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            excludes += "/META-INF/DEPENDENCIES"
         }
     }
 }
@@ -131,6 +132,11 @@ dependencies {
     implementation("androidx.work:work-runtime-ktx:2.9.0")
     implementation("com.google.accompanist:accompanist-permissions:0.34.0")
     implementation("com.google.android.gms:play-services-auth:21.1.1")
+
+    // at >= 2.3.0 gRPC version mismatch with firebase libraries
+    implementation("com.google.api-client:google-api-client-android:2.2.0")
+
+    implementation("com.google.apis:google-api-services-calendar:v3-rev411-1.25.0")
     implementation("com.google.code.gson:gson:2.10.1")
     implementation("com.google.dagger:hilt-android:2.51.1")
     implementation(platform("com.google.firebase:firebase-bom:33.0.0"))

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,14 +2,17 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
-    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.ACTIVITY_RECOGNITION"/>
     <uses-permission android:name="android.permission.BODY_SENSORS"/>
-    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_HEALTH"/>
+    <uses-permission android:name="android.permission.GET_ACCOUNTS"/>
+    <uses-permission android:name="android.permission.HIGH_SAMPLING_RATE_SENSORS"/>
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" />
+    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
     <uses-permission android:name="android.permission.health.READ_ACTIVE_CALORIES_BURNED" />
     <uses-permission android:name="android.permission.health.READ_DISTANCE" />
     <uses-permission android:name="android.permission.health.READ_EXERCISE" />
@@ -17,8 +20,6 @@
     <uses-permission android:name="android.permission.health.READ_SLEEP" />
     <uses-permission android:name="android.permission.health.READ_STEPS" />
     <uses-permission android:name="android.permission.health.READ_TOTAL_CALORIES_BURNED" />
-    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission android:name="android.permission.USE_EXACT_ALARM" />
 
     <application
         android:name=".Application"

--- a/app/src/main/java/com/pvp/app/api/TaskService.kt
+++ b/app/src/main/java/com/pvp/app/api/TaskService.kt
@@ -2,6 +2,7 @@ package com.pvp.app.api
 
 import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.GeneralTask
+import com.pvp.app.model.GoogleTask
 import com.pvp.app.model.Meal
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportActivity
@@ -183,6 +184,13 @@ interface TaskService : DocumentsCollection {
     suspend fun remove(task: Task)
 
     /**
+     * Removes a google task from the local cached data.
+     *
+     * @param task google task to remove
+     */
+    suspend fun removeGoogle(task: GoogleTask)
+
+    /**
      * Removes all tasks from the database.
      *
      * @param userEmail email of the user to remove tasks for
@@ -195,7 +203,7 @@ interface TaskService : DocumentsCollection {
      *
      * @param dateStart date to start synchronization from
      */
-    suspend fun synchronizeGoogleTasks(dateStart: LocalDate)
+    suspend fun synchronizeGoogleCalendar(dateStart: LocalDate)
 
     /**
      * Updates the task in the database.

--- a/app/src/main/java/com/pvp/app/api/TaskService.kt
+++ b/app/src/main/java/com/pvp/app/api/TaskService.kt
@@ -190,6 +190,14 @@ interface TaskService : DocumentsCollection {
     suspend fun removeAll(userEmail: String)
 
     /**
+     * Synchronizes google calendar events/tasks from certain date onwards with the local
+     * cached data.
+     *
+     * @param dateStart date to start synchronization from
+     */
+    suspend fun synchronizeGoogleTasks(dateStart: LocalDate)
+
+    /**
      * Updates the task in the database.
      *
      * @param task task to update

--- a/app/src/main/java/com/pvp/app/common/TimeUtil.kt
+++ b/app/src/main/java/com/pvp/app/common/TimeUtil.kt
@@ -31,7 +31,7 @@ object TimeUtil {
      * Parses LocalTime object to a string
      * @return HH:mm or HH:mm - HH:mm if range is provided
      */
-    fun LocalTime.asString(range: Duration?): String {
+    fun LocalTime.asString(range: Duration? = null): String {
         return if (range == null) {
             format(DateTimeFormatter.ofPattern("HH:mm"))
         } else {

--- a/app/src/main/java/com/pvp/app/model/Tasks.kt
+++ b/app/src/main/java/com/pvp/app/model/Tasks.kt
@@ -264,6 +264,26 @@ class SportTask(
 }
 
 @Serializable
+class GoogleTask(
+    override val date: LocalDate,
+    val description: String? = null,
+    override val id: String?,
+    override val time: LocalTime? = null,
+    override val title: String
+) : Task() {
+
+    override val duration: Duration? = null
+    override val isCompleted: Boolean = false
+    override val points: Points = Points()
+    override val reminderTime: Duration? = null
+    override val userEmail: String = ""
+
+    override fun toString(): String {
+        return "GoogleTask(title='$title', description=$description, id=$id, date=$date, time=$time)"
+    }
+}
+
+@Serializable
 class GeneralTask(
     override val date: LocalDate,
     val description: String? = null,

--- a/app/src/main/java/com/pvp/app/service/TaskServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/TaskServiceImpl.kt
@@ -431,6 +431,15 @@ class TaskServiceImpl @Inject constructor(
             .await()
     }
 
+    override suspend fun removeGoogle(task: GoogleTask) {
+        editGoogleEventTasks(
+            context,
+            getGoogleEventTasks(context)
+                .firstOr(emptyList())
+                .filter { it.id != task.id }
+        )
+    }
+
     override suspend fun removeAll(userEmail: String) {
         database
             .collection(identifier)
@@ -446,7 +455,7 @@ class TaskServiceImpl @Inject constructor(
             }
     }
 
-    override suspend fun synchronizeGoogleTasks(dateStart: LocalDate) {
+    override suspend fun synchronizeGoogleCalendar(dateStart: LocalDate) {
         val user = userService.user.firstOrNull() ?: return
 
         val service = Calendar

--- a/app/src/main/java/com/pvp/app/service/TaskServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/TaskServiceImpl.kt
@@ -1,5 +1,19 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package com.pvp.app.service
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import com.google.api.client.googleapis.extensions.android.gms.auth.GoogleAccountCredential
+import com.google.api.client.http.javanet.NetHttpTransport
+import com.google.api.client.json.jackson2.JacksonFactory
+import com.google.api.client.util.DateTime
+import com.google.api.services.calendar.Calendar
+import com.google.api.services.calendar.CalendarScopes
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.snapshots
 import com.pvp.app.api.Configuration
@@ -9,22 +23,30 @@ import com.pvp.app.api.MealService
 import com.pvp.app.api.PointService
 import com.pvp.app.api.TaskService
 import com.pvp.app.api.UserService
+import com.pvp.app.common.FlowUtil.firstOr
 import com.pvp.app.common.JsonUtil.JSON
 import com.pvp.app.common.JsonUtil.toJsonElement
 import com.pvp.app.common.JsonUtil.toPrimitivesMap
 import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.GeneralTask
+import com.pvp.app.model.GoogleTask
 import com.pvp.app.model.Meal
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.Points
 import com.pvp.app.model.SportActivity
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.tasks.await
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.encodeToJsonElement
@@ -32,12 +54,20 @@ import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.ZoneOffset
 import javax.inject.Inject
 import kotlin.math.max
 import kotlin.math.roundToInt
 
+private val Context.dataStoreGoogleCalendarEvents: DataStore<Preferences> by preferencesDataStore(
+    name = "google_calendar_events"
+)
+
+private val eventsKey: Preferences.Key<Set<String>> = stringSetPreferencesKey("events")
+
 class TaskServiceImpl @Inject constructor(
     private val configuration: Configuration,
+    @ApplicationContext private val context: Context,
     private val database: FirebaseFirestore,
     private val exerciseService: ExerciseService,
     private val experienceService: ExperienceService,
@@ -384,6 +414,9 @@ class TaskServiceImpl @Inject constructor(
                         task
                     }
             }
+            .combine(getGoogleEventTasks(context)) { tasks, tasksGoogle ->
+                tasks.plus(tasksGoogle)
+            }
     }
 
     override suspend fun remove(task: Task) {
@@ -411,6 +444,71 @@ class TaskServiceImpl @Inject constructor(
             .forEach { d ->
                 d.reference.delete()
             }
+    }
+
+    override suspend fun synchronizeGoogleTasks(dateStart: LocalDate) {
+        val user = userService.user.firstOrNull() ?: return
+
+        val service = Calendar
+            .Builder(
+                NetHttpTransport(),
+                JacksonFactory.getDefaultInstance(),
+                GoogleAccountCredential
+                    .usingOAuth2(
+                        context,
+                        setOf(
+                            CalendarScopes.CALENDAR_READONLY,
+                            CalendarScopes.CALENDAR_EVENTS_READONLY
+                        )
+                    )
+                    .also { it.selectedAccountName = user.email }
+            )
+            .setApplicationName("Calendar")
+            .build()
+
+        val now = DateTime(System.currentTimeMillis())
+
+        val events = service
+            .calendarList()
+            .list()
+            .execute().items
+            .map { it.id }
+            .flatMap { id ->
+                service
+                    .events()
+                    .list(id)
+                    .setTimeMin(now)
+                    .setOrderBy("startTime")
+                    .setSingleEvents(true)
+                    .execute().items
+                    .map {
+                        val date = it.start.dateTime ?: it.start.date
+
+                        val dateTime = LocalDateTime.ofEpochSecond(
+                            date.value / 1000,
+                            0,
+                            ZoneOffset.ofTotalSeconds(date.timeZoneShift * 60)
+                        )
+
+                        GoogleTask(
+                            date = dateTime.toLocalDate(),
+                            description = it.description,
+                            id = it.id,
+                            time = dateTime.toLocalTime(),
+                            title = it.summary
+                        )
+                    }
+            }
+
+        val eventsAll = getGoogleEventTasks(context)
+            .firstOr(emptyList())
+            .filter { it.date < dateStart }
+            .plus(events)
+
+        editGoogleEventTasks(
+            context,
+            eventsAll
+        )
     }
 
     override suspend fun update(
@@ -476,6 +574,17 @@ class TaskServiceImpl @Inject constructor(
                 else -> {
                     JSON.decodeFromJsonElement<GeneralTask>(element)
                 }
+            }
+        }
+
+        private suspend fun editGoogleEventTasks(
+            context: Context,
+            tasks: List<GoogleTask>
+        ) {
+            context.dataStoreGoogleCalendarEvents.edit { preferences ->
+                preferences[eventsKey] = tasks
+                    .map { JSON.encodeToString<GoogleTask>(it) }
+                    .toSet()
             }
         }
 
@@ -582,6 +691,17 @@ class TaskServiceImpl @Inject constructor(
                     .take(count - 1)
                     .plus(SportActivity.Walking)
             }
+        }
+
+        private fun getGoogleEventTasks(context: Context): Flow<List<GoogleTask>> {
+            return context.dataStoreGoogleCalendarEvents.data
+                .mapLatest { it[eventsKey] ?: emptySet() }
+                .mapLatest { events ->
+                    events.map {
+                        JSON.decodeFromJsonElement<GoogleTask>(JSON.parseToJsonElement(it))
+                    }
+                }
+                .onStart { emit(emptyList()) }
         }
 
         private suspend fun isWeekly(

--- a/app/src/main/java/com/pvp/app/ui/common/Fields.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Fields.kt
@@ -1,13 +1,68 @@
 package com.pvp.app.ui.common
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun InfoCustomField(
+    label: @Composable () -> Unit,
+    value: @Composable () -> Unit
+) {
+    Box(
+        modifier = Modifier
+            .background(
+                color = MaterialTheme.colorScheme.surfaceContainer,
+                shape = MaterialTheme.shapes.medium
+            )
+            .padding(8.dp)
+            .fillMaxWidth()
+    ) {
+        Column(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalAlignment = Alignment.Start,
+            verticalArrangement = Arrangement.Center
+        ) {
+            label()
+
+            value()
+        }
+    }
+}
+
+@Composable
+fun InfoDateField(
+    label: String,
+    value: LocalDate
+) = InfoTextField(
+    label = label,
+    value = value.format(DateTimeFormatter.ofPattern("yyyy-MM-dd, EEEE"))
+)
+
+@Composable
+fun InfoTextField(
+    label: String,
+    value: String
+) = InfoCustomField(label = {
+    Text(
+        fontWeight = FontWeight.Bold,
+        text = label
+    )
+}) { Text(text = value) }
 
 @Composable
 fun ErrorFieldWrapper(

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/AnalysesOfDay.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/AnalysesOfDay.kt
@@ -34,6 +34,7 @@ import androidx.health.connect.client.PermissionController
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.GeneralTask
+import com.pvp.app.model.GoogleTask
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
@@ -172,7 +173,10 @@ private fun TasksOfDayCounterContainer(tasks: List<Task>) {
         TasksOfDayCounter(
             Icons.AutoMirrored.Outlined.LibraryBooks,
             tasks,
-            listOf(GeneralTask::class)
+            listOf(
+                GeneralTask::class,
+                GoogleTask::class
+            )
         )
 
         TasksOfDayCounter(

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/Models.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/Models.kt
@@ -7,6 +7,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.GeneralTask
+import com.pvp.app.model.GoogleTask
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportActivity
 import com.pvp.app.model.SportTask
@@ -18,6 +19,7 @@ import java.time.LocalTime
 open class TaskFormState<T : Task>(
     date: LocalDate,
     duration: Duration? = null,
+    val editable: Boolean = true,
     isFormValid: Boolean = false,
     reminderTime: Duration? = null,
     task: T? = null,
@@ -35,11 +37,12 @@ open class TaskFormState<T : Task>(
 
     constructor(state: TaskFormState<T>) : this(
         date = state.date,
-        time = state.time,
         duration = state.duration,
+        editable = state.editable,
         isFormValid = state.isFormValid,
         reminderTime = state.reminderTime,
         task = state.task,
+        time = state.time,
         title = state.title
     )
 
@@ -55,6 +58,14 @@ open class TaskFormState<T : Task>(
         description: String? = null,
         stateParent: TaskFormState<GeneralTask>
     ) : TaskFormState<GeneralTask>(stateParent) {
+
+        var description by mutableStateOf(description)
+    }
+
+    class Google(
+        description: String? = null,
+        stateParent: TaskFormState<GoogleTask>
+    ) : TaskFormState<GoogleTask>(stateParent) {
 
         var description by mutableStateOf(description)
     }
@@ -87,6 +98,7 @@ open class TaskFormState<T : Task>(
         ) = TaskFormState(
             date = task?.date ?: date ?: LocalDate.now(),
             duration = task?.duration,
+            editable = task !is GoogleTask && (task !is SportTask || !task.isDaily),
             isFormValid = task != null,
             reminderTime = task?.reminderTime,
             task = task,
@@ -122,6 +134,26 @@ open class TaskFormState<T : Task>(
             val state by remember {
                 mutableStateOf(
                     General(
+                        description = task?.description,
+                        stateParent = create(
+                            date,
+                            task
+                        )
+                    )
+                )
+            }
+
+            return state
+        }
+
+        @Composable
+        fun rememberGoogleFormState(
+            date: LocalDate? = null,
+            task: GoogleTask? = null
+        ): Google {
+            val state by remember {
+                mutableStateOf(
+                    Google(
                         description = task?.description,
                         stateParent = create(
                             date,

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
@@ -52,7 +52,7 @@ fun TaskCard(
     var checked = task.isCompleted
     var showDialog by remember { mutableStateOf(false) }
 
-    TaskEditSheet(
+    TaskPreviewSheet(
         isOpen = showDialog,
         onClose = { showDialog = false },
         task = task
@@ -72,7 +72,7 @@ fun TaskCard(
                     MaterialTheme.colorScheme.surfaceContainer.darken(0.2f)
                 )
             )
-            .clickable(enabled = !(task is SportTask && task.isDaily || task is GoogleTask)) {
+            .clickable(enabled = !(task is SportTask && task.isDaily)) {
                 showDialog = true
             }
     ) {

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskCards.kt
@@ -35,6 +35,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.pvp.app.common.TimeUtil.asString
 import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.GeneralTask
+import com.pvp.app.model.GoogleTask
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
 import com.pvp.app.ui.common.InfoTooltip
@@ -71,7 +72,7 @@ fun TaskCard(
                     MaterialTheme.colorScheme.surfaceContainer.darken(0.2f)
                 )
             )
-            .clickable(enabled = !(task is SportTask && task.isDaily)) {
+            .clickable(enabled = !(task is SportTask && task.isDaily || task is GoogleTask)) {
                 showDialog = true
             }
     ) {
@@ -86,7 +87,7 @@ fun TaskCard(
                     .padding(4.dp)
                     .fillMaxWidth()
             ) {
-                if (task.date <= LocalDate.now()) {
+                if (task !is GoogleTask && task.date <= LocalDate.now()) {
                     Checkbox(
                         checked = checked,
                         enabled = task !is SportTask || !task.isDaily || task.date == LocalDate.now(),
@@ -129,8 +130,9 @@ fun TaskCard(
                     Spacer(modifier = Modifier.height(4.dp))
 
                     when (task) {
-                        is SportTask -> TaskCardContentSport(task)
                         is CustomMealTask -> TaskCardContentMeal(task)
+                        is GoogleTask -> TaskCardContentGoogle(task)
+                        is SportTask -> TaskCardContentSport(task)
                         else -> TaskCardContent(task)
                     }
                 }
@@ -175,6 +177,38 @@ private fun TaskCardContentMeal(task: CustomMealTask) {
         text = "Recipe: " + task.recipe,
         textAlign = TextAlign.Left
     )
+}
+
+@Composable
+private fun TaskCardContentGoogle(task: GoogleTask) {
+    task.duration?.let { duration ->
+        Row(modifier = Modifier.padding(6.dp)) {
+            Icon(
+                contentDescription = "Duration",
+                imageVector = Icons.Outlined.Timelapse
+            )
+
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 8.dp),
+                text = duration.asString(),
+                textAlign = TextAlign.Left
+            )
+        }
+    }
+
+    if (task.description != null) {
+        Text(
+            maxLines = 3,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 8.dp),
+            overflow = TextOverflow.Ellipsis,
+            text = task.description,
+            textAlign = TextAlign.Left
+        )
+    }
 }
 
 @Composable

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TaskViewModel.kt
@@ -12,6 +12,7 @@ import com.pvp.app.api.TaskService
 import com.pvp.app.api.UserService
 import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.GeneralTask
+import com.pvp.app.model.GoogleTask
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.Setting
 import com.pvp.app.model.SportActivity
@@ -425,6 +426,12 @@ class TaskViewModel @Inject constructor(
             task.cancelNotification()
 
             taskService.remove(task)
+        }
+    }
+
+    fun removeGoogle(task: GoogleTask) {
+        viewModelScope.launch(Dispatchers.IO) {
+            taskService.removeGoogle(task)
         }
     }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/calendar/TasksOfDay.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/calendar/TasksOfDay.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import com.pvp.app.model.CustomMealTask
 import com.pvp.app.model.GeneralTask
+import com.pvp.app.model.GoogleTask
 import com.pvp.app.model.MealTask
 import com.pvp.app.model.SportTask
 import com.pvp.app.model.Task
@@ -105,7 +106,7 @@ private fun filterTasks(
         TaskFilter.Daily -> tasks.filter { it is SportTask && it.isDaily }
         TaskFilter.Sports -> tasks.filter { it is SportTask && !it.isDaily }
         TaskFilter.Meal -> tasks.filter { it is CustomMealTask || it is MealTask }
-        TaskFilter.General -> tasks.filterIsInstance<GeneralTask>()
+        TaskFilter.General -> tasks.filter { it is GeneralTask || it is GoogleTask }
     }
 }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -59,6 +60,7 @@ import com.pvp.app.model.Setting
 import com.pvp.app.ui.common.ButtonConfirm
 import com.pvp.app.ui.common.Picker
 import com.pvp.app.ui.common.PickerState.Companion.rememberPickerState
+import com.pvp.app.ui.common.showToast
 
 @Composable
 private fun SettingNotificationReminderMinutes(
@@ -255,9 +257,12 @@ private fun SettingHealthConnectPermissions(context: Context) {
 @Composable
 private fun GoogleCalendarSynchronizer(model: SettingsViewModel = hiltViewModel()) {
     var intent by remember { mutableStateOf<Intent?>(null) }
+    val context = LocalContext.current
 
     fun synchronize() {
-        model.synchronizeGoogleTasks { e ->
+        model.synchronizeGoogleTasks(onCallback = {
+            context.showToast(message = "Google Calendar successfully synchronized")
+        }) { e ->
             intent = when (e) {
                 is UserRecoverableAuthIOException -> e.intent
                 else -> null
@@ -273,10 +278,12 @@ private fun GoogleCalendarSynchronizer(model: SettingsViewModel = hiltViewModel(
         }
     }
 
-    if (intent != null) {
-        launcher.launch(intent!!)
+    LaunchedEffect(intent) {
+        if (intent != null) {
+            launcher.launch(intent!!)
 
-        intent = null
+            intent = null
+        }
     }
 
     SettingCard(

--- a/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsViewModel.kt
@@ -64,10 +64,17 @@ class SettingsViewModel @Inject constructor(
         return function(configuration)
     }
 
-    fun synchronizeGoogleTasks(onException: (Exception) -> Unit) {
+    fun synchronizeGoogleTasks(
+        onCallback: () -> Unit,
+        onException: (Exception) -> Unit
+    ) {
         viewModelScope.launch(Dispatchers.IO) {
             try {
-                taskService.synchronizeGoogleTasks(LocalDate.now())
+                taskService.synchronizeGoogleCalendar(LocalDate.now())
+
+                withContext(Dispatchers.Main) {
+                    onCallback()
+                }
             } catch (e: Exception) {
                 Log.e(
                     "SettingsViewModel",

--- a/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsViewModel.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/settings/SettingsViewModel.kt
@@ -1,5 +1,6 @@
 package com.pvp.app.ui.screen.settings
 
+import android.util.Log
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
@@ -9,16 +10,20 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pvp.app.api.Configuration
 import com.pvp.app.api.SettingService
+import com.pvp.app.api.TaskService
 import com.pvp.app.model.Setting
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.time.LocalDate
 import javax.inject.Inject
 
 @HiltViewModel
 class SettingsViewModel @Inject constructor(
     private val configuration: Configuration,
-    private val settingService: SettingService
+    private val settingService: SettingService,
+    private val taskService: TaskService
 ) : ViewModel() {
 
     fun clear() {
@@ -57,5 +62,22 @@ class SettingsViewModel @Inject constructor(
 
     fun <T> fromConfiguration(function: (Configuration) -> T): T {
         return function(configuration)
+    }
+
+    fun synchronizeGoogleTasks(onException: (Exception) -> Unit) {
+        viewModelScope.launch(Dispatchers.IO) {
+            try {
+                taskService.synchronizeGoogleTasks(LocalDate.now())
+            } catch (e: Exception) {
+                Log.e(
+                    "SettingsViewModel",
+                    "Google Calendar synchronization failed: ${e.message}"
+                )
+
+                withContext(Dispatchers.Main) {
+                    onException(e)
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
# Changes

- Pretty much ordered AndroidManifest permissions and added one more (GET_ACCOUNTS), doubt it's needed, but.. eh.
- Synchronization is made manually by going into settings screen and clicking synchronize button.
- User is asked to give some consent for certain permissions.
  - Ugly consent screen is shown, because our app is not verified.
- Google task model created
- Added new task card type that shows description for google tasks
- Not allowing to preview or edit google tasks, only allowing to preview task cards. Description should fit only 3 lines at most. No clue how we could go around this. Maybe show custom edit form that doesn't allow editing, only shows full description/title/times/etc. ?
- Synchronized tasks are stored locally.
- Synchronizing only future tasks (including current day)