### PR TITLE
PVP-275 Add week meal plan generation

### DIFF
--- a/app/src/main/java/com/pvp/app/Application.kt
+++ b/app/src/main/java/com/pvp/app/Application.kt
@@ -23,12 +23,14 @@ import com.pvp.app.worker.DailyTaskWorker
 import com.pvp.app.worker.DailyTaskWorkerSetup
 import com.pvp.app.worker.DrinkReminderWorker
 import com.pvp.app.worker.GoalMotivationWorker
+import com.pvp.app.worker.MealPlanWorker
 import com.pvp.app.worker.TaskNotificationWorker
 import com.pvp.app.worker.TaskPointsDeductionWorkerSetup
 import com.pvp.app.worker.WeeklyActivityWorker
 import dagger.hilt.android.HiltAndroidApp
 import okhttp3.OkHttpClient
 import java.time.Duration
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import java.util.concurrent.TimeUnit
@@ -60,6 +62,8 @@ class Application : Application(), Configuration.Provider, ImageLoaderFactory {
         createDrinkReminderWorker()
 
         createGoalMotivationWorker()
+
+        createMealPlanWorker()
 
         createNotificationChannels()
 
@@ -177,6 +181,41 @@ class Application : Application(), Configuration.Provider, ImageLoaderFactory {
             GoalMotivationWorker.WORKER_NAME,
             ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
             request
+        )
+    }
+
+    private fun createMealPlanWorker() {
+        val request = OneTimeWorkRequestBuilder<MealPlanWorker>()
+            .build()
+
+        workManager.enqueue(request)
+
+        val daysDelay = LocalDate
+            .now().dayOfWeek.value
+            .let { dayOfWeek ->
+                if (dayOfWeek == 1) {
+                    0
+                } else {
+                    8 - dayOfWeek
+                }
+            }
+
+        val requestPeriodic = PeriodicWorkRequestBuilder<MealPlanWorker>(
+            repeatInterval = 7,
+            repeatIntervalTimeUnit = TimeUnit.DAYS
+        )
+            .setInitialDelay(
+                Duration.of(
+                    daysDelay.toLong(),
+                    ChronoUnit.DAYS
+                )
+            )
+            .build()
+
+        workManager.enqueueUniquePeriodicWork(
+            MealPlanWorker.WORKER_NAME,
+            ExistingPeriodicWorkPolicy.CANCEL_AND_REENQUEUE,
+            requestPeriodic
         )
     }
 

--- a/app/src/main/java/com/pvp/app/api/MealService.kt
+++ b/app/src/main/java/com/pvp/app/api/MealService.kt
@@ -2,11 +2,20 @@ package com.pvp.app.api
 
 import com.pvp.app.model.Meal
 import kotlinx.coroutines.flow.Flow
+import java.time.DayOfWeek
 
 interface MealService : DocumentsCollection {
 
     override val identifier: String
         get() = "meals"
+
+    /**
+     * Generates a week meal plan based on the meals in the database and user diet preferences.
+     * The plan will contain 3 meals for each day of the week.
+     *
+     * @return a map of the week meal plan.
+     */
+    suspend fun generateWeekPlan(): Map<DayOfWeek, List<Meal>>
 
     /**
      * @return a flow of all meals in the database.

--- a/app/src/main/java/com/pvp/app/api/TaskService.kt
+++ b/app/src/main/java/com/pvp/app/api/TaskService.kt
@@ -168,6 +168,12 @@ interface TaskService : DocumentsCollection {
     ): List<SportTask>
 
     /**
+     * Generates meal tasks for current week, starting from today, for current user.
+     * This happens by using [MealService.generateWeekPlan] to get the meals for the week
+     */
+    suspend fun generateMeal()
+
+    /**
      * Gets all tasks for the given user by its email.
      *
      * @param userEmail email of the user to get tasks for

--- a/app/src/main/java/com/pvp/app/common/DateUtil.kt
+++ b/app/src/main/java/com/pvp/app/common/DateUtil.kt
@@ -9,6 +9,7 @@ import java.time.YearMonth
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.time.format.TextStyle
+import java.time.temporal.TemporalAdjusters
 import java.util.Date
 import java.util.Locale
 
@@ -119,5 +120,20 @@ object DateUtil {
                 .systemDefault().rules
                 .getOffset(this)
         )
+    }
+
+    /**
+     * Compares current date with specified day of the week and returns the nearest date of that day.
+     *
+     * @return LocalDate of the nearest day of the week
+     */
+    fun DayOfWeek.toNearestDate(): LocalDate {
+        val today = LocalDate.now()
+
+        return if (today.dayOfWeek == this) {
+            today
+        } else {
+            today.with(TemporalAdjusters.next(this))
+        }
     }
 }

--- a/app/src/main/java/com/pvp/app/model/Diet.kt
+++ b/app/src/main/java/com/pvp/app/model/Diet.kt
@@ -1,0 +1,16 @@
+package com.pvp.app.model
+
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.res.stringResource
+import com.pvp.app.R
+
+enum class Diet(@StringRes val titleId: Int) {
+
+    Carbohydrates(R.string.diet_carbohydrates),
+    Fat(R.string.diet_fat),
+    Protein(R.string.diet_protein);
+
+    val title: String
+        @Composable get() = stringResource(titleId)
+}

--- a/app/src/main/java/com/pvp/app/model/Diet.kt
+++ b/app/src/main/java/com/pvp/app/model/Diet.kt
@@ -9,7 +9,8 @@ enum class Diet(@StringRes val titleId: Int) {
 
     Carbohydrates(R.string.diet_carbohydrates),
     Fat(R.string.diet_fat),
-    Protein(R.string.diet_protein);
+    Protein(R.string.diet_protein),
+    TakeEverything(R.string.diet_take_everything);
 
     val title: String
         @Composable get() = stringResource(titleId)

--- a/app/src/main/java/com/pvp/app/model/User.kt
+++ b/app/src/main/java/com/pvp/app/model/User.kt
@@ -10,6 +10,7 @@ data class User(
     var decorationsApplied: List<String> = emptyList(),
     var decorationsOwned: List<String> = emptyList(),
     var diet: Diet = Diet.Carbohydrates,
+    var lastMealPlanGeneratedWeek: Int = 0,
     var hasDisability: Boolean = false,
     val email: String = "",
     var experience: Int = 0,

--- a/app/src/main/java/com/pvp/app/model/User.kt
+++ b/app/src/main/java/com/pvp/app/model/User.kt
@@ -9,6 +9,7 @@ data class User(
     var activities: List<SportActivity> = emptyList(),
     var decorationsApplied: List<String> = emptyList(),
     var decorationsOwned: List<String> = emptyList(),
+    var diet: Diet = Diet.Carbohydrates,
     var hasDisability: Boolean = false,
     val email: String = "",
     var experience: Int = 0,

--- a/app/src/main/java/com/pvp/app/model/User.kt
+++ b/app/src/main/java/com/pvp/app/model/User.kt
@@ -10,7 +10,6 @@ data class User(
     var decorationsApplied: List<String> = emptyList(),
     var decorationsOwned: List<String> = emptyList(),
     var diet: Diet = Diet.Carbohydrates,
-    var lastMealPlanGeneratedWeek: Int = 0,
     var hasDisability: Boolean = false,
     val email: String = "",
     var experience: Int = 0,
@@ -18,6 +17,7 @@ data class User(
     var ingredients: List<Ingredient> = emptyList(),
     @Contextual
     var lastActivitySync: Timestamp? = null,
+    var lastMealPlanGeneratedWeek: Int = 0,
     var level: Int = 0,
     var mass: Int = 0,
     var points: Int = 0,

--- a/app/src/main/java/com/pvp/app/service/MealServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/MealServiceImpl.kt
@@ -6,6 +6,7 @@ import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.snapshots
 import com.pvp.app.api.MealService
 import com.pvp.app.api.UserService
+import com.pvp.app.model.Diet
 import com.pvp.app.model.Meal
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -14,12 +15,23 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.mapLatest
 import java.time.DayOfWeek
+import java.time.LocalDate
 import javax.inject.Inject
+import kotlin.math.max
 
 class MealServiceImpl @Inject constructor(
     private val database: FirebaseFirestore,
     private val userService: UserService
 ) : MealService {
+
+    private val breakfastAliases = listOf(
+        "appetizer",
+        "breakfast",
+        "salad",
+        "side dish",
+        "snack",
+        "starter"
+    )
 
     override suspend fun generateWeekPlan(): Map<DayOfWeek, List<Meal>> {
         val user = userService.user.firstOrNull()
@@ -28,8 +40,128 @@ class MealServiceImpl @Inject constructor(
 
         val meals = get()
             .first()
+            .filter {
+                it.recipe
+                    .first().steps
+                    .none { step ->
+                        step.ingredients.any { ingredient ->
+                            user.ingredients
+                                .map { ingredientBlocked -> ingredientBlocked.name }
+                                .any { ingredientBlocked ->
+                                    ingredient.contains(
+                                        ingredientBlocked,
+                                        ignoreCase = true
+                                    )
+                                }
+                        }
+                    }
+            }
 
-        return emptyMap()
+        val dayNow = LocalDate.now().dayOfWeek
+
+        val daysToMeals = DayOfWeek.entries
+            .toList()
+            .subList(
+                DayOfWeek.entries.indexOf(DayOfWeek.entries.first { it == dayNow }),
+                DayOfWeek.entries.size
+            )
+            .associateWith { _ -> mutableListOf<Meal>() }
+
+        var mealsBreakfast = meals
+            .filter {
+                when (user.diet) {
+                    Diet.Carbohydrates -> it.nutrition.caloricBreakdown.percentCarbs
+                    Diet.Fat -> it.nutrition.caloricBreakdown.percentFat
+                    Diet.Protein -> it.nutrition.caloricBreakdown.percentProtein
+                    else -> 100.0
+                } >= 10
+            }
+            .filter {
+                it.dishTypes.any { type ->
+                    breakfastAliases.any { alias ->
+                        alias.contains(
+                            type,
+                            ignoreCase = true
+                        )
+                    }
+                }
+            }
+
+        require(mealsBreakfast.isNotEmpty()) {
+            "No breakfast meals found. Please add some meals to the database."
+        }
+
+        daysToMeals.forEach { (day, mealsOfDay) ->
+            mealsBreakfast = mealsBreakfast.shuffled()
+
+            val breakfast = mealsBreakfast.firstOrNull()
+
+            if (breakfast != null) {
+                mealsBreakfast = mealsBreakfast.subList(
+                    1,
+                    mealsBreakfast.size
+                )
+
+                mealsOfDay.add(breakfast)
+            } else {
+                val breakfastOld = daysToMeals[day.minus(1)]?.firstOrNull()
+
+                if (breakfastOld != null) {
+                    mealsOfDay.add(breakfastOld)
+                }
+            }
+        }
+
+        val mealsMain = meals.filter {
+            when (user.diet) {
+                Diet.Carbohydrates -> it.nutrition.caloricBreakdown.percentCarbs
+                Diet.Fat -> it.nutrition.caloricBreakdown.percentFat
+                Diet.Protein -> it.nutrition.caloricBreakdown.percentProtein
+                else -> 100.0
+            } >= 40
+        }
+
+        require(mealsMain.isNotEmpty()) {
+            "No main meals found. Please add some meals to the database and make sure " +
+                    "they have at least 40% of the required nutrients."
+        }
+
+        daysToMeals.forEach { (day, mealsOfDay) ->
+            if (mealsOfDay.size > 2 || mealsMain.isEmpty()) {
+                return@forEach
+            }
+
+            repeat(2) {
+                val main = mealsMain
+                    .shuffled()
+                    .firstOrNull()
+
+                if (main == null) {
+                    return@forEach
+                }
+
+                val servings = max(
+                    3,
+                    main.servings / 2
+                )
+
+                for (i in 0 until servings + 1) {
+                    val dayTarget = day.plus(i.toLong())
+
+                    if (dayTarget < day) {
+                        break
+                    }
+
+                    val dayMeals = daysToMeals[dayTarget]!!
+
+                    if (dayMeals.size < 3) {
+                        dayMeals.add(main)
+                    }
+                }
+            }
+        }
+
+        return daysToMeals
     }
 
     override fun get(): Flow<List<Meal>> {

--- a/app/src/main/java/com/pvp/app/service/MealServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/MealServiceImpl.kt
@@ -5,16 +5,32 @@ package com.pvp.app.service
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.snapshots
 import com.pvp.app.api.MealService
+import com.pvp.app.api.UserService
 import com.pvp.app.model.Meal
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.mapLatest
+import java.time.DayOfWeek
 import javax.inject.Inject
 
 class MealServiceImpl @Inject constructor(
-    private val database: FirebaseFirestore
+    private val database: FirebaseFirestore,
+    private val userService: UserService
 ) : MealService {
+
+    override suspend fun generateWeekPlan(): Map<DayOfWeek, List<Meal>> {
+        val user = userService.user.firstOrNull()
+
+        user ?: error("User is not logged in")
+
+        val meals = get()
+            .first()
+
+        return emptyMap()
+    }
 
     override fun get(): Flow<List<Meal>> {
         return database

--- a/app/src/main/java/com/pvp/app/service/MealServiceImpl.kt
+++ b/app/src/main/java/com/pvp/app/service/MealServiceImpl.kt
@@ -88,7 +88,7 @@ class MealServiceImpl @Inject constructor(
             }
 
         require(mealsBreakfast.isNotEmpty()) {
-            "No breakfast meals found. Please add some meals to the database."
+            "No breakfast meals found. Administrators, please add some meals to the database."
         }
 
         daysToMeals.forEach { (day, mealsOfDay) ->
@@ -122,8 +122,8 @@ class MealServiceImpl @Inject constructor(
         }
 
         require(mealsMain.isNotEmpty()) {
-            "No main meals found. Please add some meals to the database and make sure " +
-                    "they have at least 40% of the required nutrients."
+            "No main meals found. Administrators, please add some meals to the database and " +
+                    "make sure they have at least 40% of the required nutrients."
         }
 
         daysToMeals.forEach { (day, mealsOfDay) ->

--- a/app/src/main/java/com/pvp/app/ui/common/Inputs.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Inputs.kt
@@ -252,6 +252,7 @@ fun EditableTextItem(
 
 @Composable
 fun <T> EditablePickerItem(
+    editLabel: String,
     label: String,
     items: List<T>,
     itemsLabel: @Composable (T) -> String,
@@ -273,7 +274,7 @@ fun <T> EditablePickerItem(
                 )
             }
         },
-        dialogTitle = { Text("Editing $label") },
+        dialogTitle = { Text(editLabel) },
         label = {
             Text(
                 fontWeight = FontWeight.Bold,

--- a/app/src/main/java/com/pvp/app/ui/common/Inputs.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Inputs.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.pvp.app.R
+import com.pvp.app.common.CollectionUtil.indexOfOrNull
 import com.pvp.app.model.SportActivity
 import com.pvp.app.ui.common.PickerState.Companion.rememberPickerState
 import java.time.Duration
@@ -247,6 +248,46 @@ fun EditableTextItem(
             text = errorMessage
         )
     }
+}
+
+@Composable
+fun <T> EditablePickerItem(
+    label: String,
+    items: List<T>,
+    itemsLabel: @Composable (T) -> String,
+    onValueChange: (T) -> Unit,
+    value: T,
+    valueLabel: @Composable (T) -> String
+) {
+    var valueEdit by remember(value) { mutableStateOf(value) }
+
+    EditableInfoItem(
+        dialogContent = {
+            Column {
+                Picker(
+                    items = items,
+                    label = { itemsLabel(it) },
+                    onChange = { valueEdit = it },
+                    startIndex = items.indexOfOrNull(valueEdit) ?: 0,
+                    state = rememberPickerState(initialValue = valueEdit)
+                )
+            }
+        },
+        dialogTitle = { Text("Editing $label") },
+        label = {
+            Text(
+                fontWeight = FontWeight.Bold,
+                text = label
+            )
+        },
+        onConfirm = { onValueChange(valueEdit) },
+        onDismiss = { },
+        value = {
+            if (value != null) {
+                Text(valueLabel(value))
+            }
+        }
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/pvp/app/ui/common/Pickers.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Pickers.kt
@@ -40,7 +40,9 @@ class PickerState<T>(initialValue: T) {
     companion object {
 
         @Composable
-        fun <T> rememberPickerState(initialValue: T) = remember(initialValue) { PickerState(initialValue) }
+        fun <T> rememberPickerState(initialValue: T) = remember(initialValue) {
+            PickerState(initialValue)
+        }
     }
 }
 

--- a/app/src/main/java/com/pvp/app/ui/common/Pickers.kt
+++ b/app/src/main/java/com/pvp/app/ui/common/Pickers.kt
@@ -40,9 +40,7 @@ class PickerState<T>(initialValue: T) {
     companion object {
 
         @Composable
-        fun <T> rememberPickerState(initialValue: T) = remember(initialValue) {
-            PickerState(initialValue)
-        }
+        fun <T> rememberPickerState(initialValue: T) = remember(initialValue) { PickerState(initialValue) }
     }
 }
 

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
@@ -392,6 +392,8 @@ private fun Properties(
             valueLabel = localeMeasurementCentimeters
         )
 
+        val localeSuccessDiet = stringResource(R.string.input_field_diet_success)
+
         EditablePickerItem(
             editLabel = stringResource(R.string.input_field_diet_edit_label),
             label = stringResource(R.string.input_field_diet_label),
@@ -402,7 +404,7 @@ private fun Properties(
             onValueChange = {
                 onUpdateDiet(it)
 
-                showSnackbar("Your diet has been updated")
+                showSnackbar(localeSuccessDiet)
             }
         )
 

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
@@ -49,6 +49,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.pvp.app.R
+import com.pvp.app.model.Diet
 import com.pvp.app.model.Ingredient
 import com.pvp.app.model.SportActivity
 import com.pvp.app.ui.common.ButtonConfirm
@@ -304,6 +305,7 @@ fun ProfileScreen(
 
             Properties(
                 onUpdateActivities = { viewModel.update { u -> u.activities = it } },
+                onUpdateDiet = { viewModel.update { u -> u.diet = it } },
                 onUpdateIngredients = { viewModel.update { u -> u.ingredients = it } },
                 onUpdateHeight = { viewModel.update { u -> u.height = it } },
                 onUpdateMass = { viewModel.update { u -> u.mass = it } },
@@ -319,6 +321,7 @@ fun ProfileScreen(
 private fun Properties(
     model: ProfileViewModel = hiltViewModel(),
     onUpdateActivities: (List<SportActivity>) -> Unit,
+    onUpdateDiet: (Diet) -> Unit,
     onUpdateHeight: (Int) -> Unit,
     onUpdateIngredients: (List<Ingredient>) -> Unit,
     onUpdateMass: (Int) -> Unit,
@@ -387,6 +390,19 @@ private fun Properties(
             },
             value = height,
             valueLabel = localeMeasurementCentimeters
+        )
+
+        EditablePickerItem(
+            label = "Diet",
+            value = state.user.diet,
+            valueLabel = { it.title },
+            items = Diet.entries,
+            itemsLabel = { it.title },
+            onValueChange = {
+                onUpdateDiet(it)
+
+                showSnackbar("Your diet has been updated")
+            }
         )
 
 

--- a/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
+++ b/app/src/main/java/com/pvp/app/ui/screen/profile/ProfileScreen.kt
@@ -393,7 +393,8 @@ private fun Properties(
         )
 
         EditablePickerItem(
-            label = "Diet",
+            editLabel = stringResource(R.string.input_field_diet_edit_label),
+            label = stringResource(R.string.input_field_diet_label),
             value = state.user.diet,
             valueLabel = { it.title },
             items = Diet.entries,

--- a/app/src/main/java/com/pvp/app/worker/MealPlanWorker.kt
+++ b/app/src/main/java/com/pvp/app/worker/MealPlanWorker.kt
@@ -1,0 +1,58 @@
+package com.pvp.app.worker
+
+import android.content.Context
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.pvp.app.api.TaskService
+import com.pvp.app.api.UserService
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.flow.firstOrNull
+import java.time.LocalDate
+import java.time.temporal.WeekFields
+import java.util.Locale
+
+@HiltWorker
+class MealPlanWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val taskService: TaskService,
+    private val userService: UserService
+) : CoroutineWorker(
+    context,
+    workerParams
+) {
+
+    override suspend fun doWork(): Result {
+        val user = userService.user.firstOrNull()
+
+        user ?: return Result.retry()
+
+        val week = LocalDate
+            .now()
+            .get(
+                WeekFields
+                    .of(AppCompatDelegate.getApplicationLocales()[0] ?: Locale.getDefault())
+                    .weekOfWeekBasedYear()
+            )
+
+        if (user.lastMealPlanGeneratedWeek >= week) {
+            return Result.success()
+        }
+
+        taskService.generateMeal()
+
+        user.lastMealPlanGeneratedWeek = week
+
+        userService.merge(user)
+
+        return Result.success()
+    }
+
+    companion object {
+
+        const val WORKER_NAME = "MealPlanWorker"
+    }
+}

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -81,6 +81,10 @@
     <string name="decoration_type_head">Galva</string>
     <string name="decoration_type_leggings">Kelnės</string>
     <string name="decoration_type_shoes">Batai</string>
+    <string name="diet_carbohydrates">Angliavandeniai</string>
+    <string name="diet_fat">Riebalai</string>
+    <string name="diet_protein">Baltymai</string>
+    <string name="diet_take_everything">Valgau viską</string>
     <string name="drawer_application_motto">Susiplanuok Savo Dieną</string>
     <string name="drawer_button_sign_out">Atsijungti</string>
     <string name="drawer_button_sign_out_confirmation">Ar tikrai norite atsijungti?</string>
@@ -179,6 +183,8 @@
     <string name="input_field_date_label">Data</string>
     <string name="input_field_description_edit_label">Redaguojate aprašymą</string>
     <string name="input_field_description_label">Aprašymas</string>
+    <string name="input_field_diet_edit_label">Redaguojate dietą</string>
+    <string name="input_field_diet_label">Dieta</string>
     <string name="input_field_distance_edit_label">Redaguojate atstumą</string>
     <string name="input_field_distance_label">Atstumas</string>
     <string name="input_field_duration_edit_label">Redaguojate trukmę</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -185,6 +185,7 @@
     <string name="input_field_description_label">Aprašymas</string>
     <string name="input_field_diet_edit_label">Redaguojate dietą</string>
     <string name="input_field_diet_label">Dieta</string>
+    <string name="input_field_diet_success">Jūsų dieta sėkmingai atnaujinta</string>
     <string name="input_field_distance_edit_label">Redaguojate atstumą</string>
     <string name="input_field_distance_label">Atstumas</string>
     <string name="input_field_duration_edit_label">Redaguojate trukmę</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -319,6 +319,7 @@
     <string name="task_type_general">Bendrinės</string>
     <string name="task_type_meal">Patiekalų</string>
     <string name="task_type_set_meal">Receptų</string>
+    <string name="task_type_set_meal_label">Dieta #%1$d: %2$s</string>
     <string name="task_type_sport">Sporto</string>
     <string name="worker_activity_notification_many">%1$s ir %2$s veiklos duos daugiau taškų šią savaitę!</string>
     <string name="worker_activity_notification_single_activity">Dalyvavimas "%1$s" veikloje duos daugiau taškų šią savaitę!</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,6 +81,9 @@
     <string name="decoration_type_head">Head</string>
     <string name="decoration_type_leggings">Leggings</string>
     <string name="decoration_type_shoes">Shoes</string>
+    <string name="diet_carbohydrates">Carbohydrates</string>
+    <string name="diet_fat">Fat</string>
+    <string name="diet_protein">Protein</string>
     <string name="drawer_application_motto">Schedule Your Day</string>
     <string name="drawer_button_sign_out">Sign Out</string>
     <string name="drawer_button_sign_out_confirmation">Are you sure you want to sign out?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -188,6 +188,7 @@
     <string name="input_field_description_label">Description</string>
     <string name="input_field_diet_edit_label">Editing diet</string>
     <string name="input_field_diet_label">Diet</string>
+    <string name="input_field_diet_success">Your diet has been updated</string>
     <string name="input_field_distance_edit_label">Editing distance</string>
     <string name="input_field_distance_label">Distance</string>
     <string name="input_field_distance_total" translatable="false">%1$.2f km distance</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,8 @@
     <string name="input_field_date_label">Date</string>
     <string name="input_field_description_edit_label">Editing description</string>
     <string name="input_field_description_label">Description</string>
+    <string name="input_field_diet_edit_label">Editing diet</string>
+    <string name="input_field_diet_label">Diet</string>
     <string name="input_field_distance_edit_label">Editing distance</string>
     <string name="input_field_distance_label">Distance</string>
     <string name="input_field_distance_total" translatable="false">%1$.2f km distance</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -84,6 +84,7 @@
     <string name="diet_carbohydrates">Carbohydrates</string>
     <string name="diet_fat">Fat</string>
     <string name="diet_protein">Protein</string>
+    <string name="diet_take_everything">Taking Everything</string>
     <string name="drawer_application_motto">Schedule Your Day</string>
     <string name="drawer_button_sign_out">Sign Out</string>
     <string name="drawer_button_sign_out_confirmation">Are you sure you want to sign out?</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -331,6 +331,7 @@
     <string name="task_type_general">General</string>
     <string name="task_type_meal">Meal</string>
     <string name="task_type_set_meal">Set Meals</string>
+    <string name="task_type_set_meal_label">Diet #%1$d: %2$s</string>
     <string name="task_type_sport">Sport</string>
     <string name="worker_activity_notification_many">%1$s and %2$s will give you more points this week!</string>
     <string name="worker_activity_notification_single_activity">Participating in %1$s will give you more points this week!</string>


### PR DESCRIPTION
# Changes
- Adjusted user model to implement meal plan generation
- Added `Diet` field in profile screen
- Created generic EditablePickerItem (?) input
- Meal plan is generated weekly
  - Only 3 meals are generated for day.
    - If meal has many servings, we propagate it to next 1-2 days.
  - One of the meals is breakfast, takes 10% of user's diet
  - Other meals take 40% of user's diet
  - (If meal contains such % of macro elements, we include it).
- 4 diets created:
  - Carbs, Fat, Proteins, *Anything*
- If meals are missing after filter process error is thrown so that we could find out that not all cases are handled. While testing error wasn't thrown even when all ingredients were chosen as not tolerated. So for now it seems fine with all diets and selected 40% threshold.